### PR TITLE
Fix amperage selector multilining

### DIFF
--- a/src/app/components/ShoreInputLimitSelector.js
+++ b/src/app/components/ShoreInputLimitSelector.js
@@ -5,6 +5,9 @@ const USAmperage = [10, 15, 20, 30, 50, 100]
 const EUAmperage = [6, 10, 13, 16, 25, 32, 63]
 
 class ShoreInputLimitSelector extends Component {
+  state = {
+    showEmpties: false
+  }
   /**
    * - Mask the Product id with `0xFF00`
    * - If the result is `0x1900` or `0x2600` it is an EU model (230VAC)
@@ -22,6 +25,13 @@ class ShoreInputLimitSelector extends Component {
     }
   }
 
+  componentDidMount() {
+    const container = document.getElementsByClassName("amperage-selector")[0]
+    const selectorButton = document.getElementsByClassName("selector-button__amperage")[0]
+    const showEmpties = container && selectorButton && container.clientHeight > selectorButton.clientHeight * 2
+    this.setState({ showEmpties: showEmpties })
+  }
+
   render(props, state) {
     const maxLimit = props.maxLimit || 100
     const amperageList = this.getSuggestedAmperageValuesList(props.productId).filter(value => {
@@ -32,28 +42,24 @@ class ShoreInputLimitSelector extends Component {
       <div className="amperage-selector__container">
         <div className="amperage-selector">
           <div className="text text--large text--center amperage-selector__description">Select shore input limit</div>
-          {amperageList
-            .map(currentValue => {
-              return (
-                <button
-                  className={
-                    "selector-button selector-button__amperage text text--very-large" +
-                    (parseInt(props.currentLimit) == currentValue ? " selector-button--active" : "")
-                  }
-                  href="#"
-                  onClick={() => props.onLimitSelected(currentValue)}
-                >
-                  {currentValue}A
-                </button>
-              )
-            })
-            // Add these to "cheat" the flexbox and allow center alignment of selector buttons
-            // AND left alignment to the last row of buttons if multilined
-            .concat(
-              amperageList.map(() => {
-                return <div className="empty" />
-              })
-            )}
+          {amperageList.map(currentValue => {
+            return (
+              <button
+                className={
+                  "selector-button selector-button__amperage text text--very-large" +
+                  (parseInt(props.currentLimit) == currentValue ? " selector-button--active" : "")
+                }
+                href="#"
+                onClick={() => props.onLimitSelected(currentValue)}
+              >
+                {currentValue}A
+              </button>
+            )
+          })}
+
+          {// Add these to "cheat" the flexbox and allow center alignment of selector buttons
+          // AND left alignment to the last row of buttons if multilined
+          state.showEmpties && amperageList.map(() => <div className="empty" />)}
         </div>
       </div>
     )

--- a/src/app/components/ShoreInputLimitSelector.js
+++ b/src/app/components/ShoreInputLimitSelector.js
@@ -8,6 +8,10 @@ class ShoreInputLimitSelector extends Component {
   state = {
     showEmpties: false
   }
+
+  firstSelectorButtonNode = null
+  amperageContainerNode = null
+
   /**
    * - Mask the Product id with `0xFF00`
    * - If the result is `0x1900` or `0x2600` it is an EU model (230VAC)
@@ -26,8 +30,8 @@ class ShoreInputLimitSelector extends Component {
   }
 
   componentDidMount() {
-    const container = document.getElementsByClassName("amperage-selector")[0]
-    const selectorButton = document.getElementsByClassName("selector-button__amperage")[0]
+    const container = this.amperageContainerNode
+    const selectorButton = this.firstSelectorButtonNode
     const showEmpties = container && selectorButton && container.clientHeight > selectorButton.clientHeight * 2
     this.setState({ showEmpties: showEmpties })
   }
@@ -41,9 +45,9 @@ class ShoreInputLimitSelector extends Component {
 
     return (
       <div className="amperage-selector__container">
-        <div className="amperage-selector">
+        <div className="amperage-selector" ref={node => (this.amperageContainerNode = node)}>
           <div className="text text--large text--center amperage-selector__description">Select shore input limit</div>
-          {amperageList.map(currentValue => {
+          {amperageList.map((currentValue, index) => {
             return (
               <button
                 className={
@@ -51,6 +55,7 @@ class ShoreInputLimitSelector extends Component {
                   (currentlySelectedLimit == currentValue ? " selector-button--active" : "")
                 }
                 onClick={() => props.onLimitSelected(currentValue)}
+                ref={node => (index === 0 ? (this.firstSelectorButtonNode = node) : null)}
               >
                 {currentValue}A
               </button>

--- a/src/app/components/ShoreInputLimitSelector.js
+++ b/src/app/components/ShoreInputLimitSelector.js
@@ -37,6 +37,7 @@ class ShoreInputLimitSelector extends Component {
     const amperageList = this.getSuggestedAmperageValuesList(props.productId).filter(value => {
       return value <= maxLimit
     })
+    const currentlySelectedLimit = parseInt(props.currentLimit)
 
     return (
       <div className="amperage-selector__container">
@@ -47,9 +48,8 @@ class ShoreInputLimitSelector extends Component {
               <button
                 className={
                   "selector-button selector-button__amperage text text--very-large" +
-                  (parseInt(props.currentLimit) == currentValue ? " selector-button--active" : "")
+                  (currentlySelectedLimit == currentValue ? " selector-button--active" : "")
                 }
-                href="#"
                 onClick={() => props.onLimitSelected(currentValue)}
               >
                 {currentValue}A

--- a/src/css/styles.scss
+++ b/src/css/styles.scss
@@ -384,7 +384,7 @@ header {
   line-height: 1.2;
 }
 
-.selector-button:not(:first-child) {
+.inverter-charger__mode-selector > .selector-button:not(:first-child) {
   margin-left: 10px;
 }
 
@@ -499,12 +499,8 @@ button:disabled {
   height: 0;
   padding-top: 0;
   padding-bottom: 0;
-  margin: 0px 10px;
+  margin: 0 10px;
   width: 130px;
-
-  @media all and (min-width: 880px) {
-    display: none;
-  }
 
   @media all and (max-width: 729px) {
     width: 110px;
@@ -516,6 +512,7 @@ button:disabled {
 
   @media all and (max-width: 400px) {
     width: 50px;
+    margin: 0 5px;
   }
 }
 


### PR DESCRIPTION
Determine whether or not to show "filler" elements in the amperage
selector in order to left align the last row of selector elements. Show
if selector container height is more than 2x the selector buttons'
height.