### PR TITLE
Add enzyme-like unit testing support

### DIFF
--- a/jestconfig.json
+++ b/jestconfig.json
@@ -1,4 +1,5 @@
 {
   "testRegex": "(/__tests__/.*|(\\.|/)(test|spec))\\.(jsx?)$",
-  "moduleFileExtensions": ["js", "jsx", "json", "node"]
+  "moduleFileExtensions": ["js", "jsx", "json", "node"],
+  "snapshotSerializers": [ "preact-render-spy/snapshot" ]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -6577,6 +6577,12 @@
       "integrity": "sha1-gteb/zCmfEAF/9XiUVMArZyk168=",
       "dev": true
     },
+    "lodash.isequal": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
+      "integrity": "sha1-QVxEePK8wwEgwizhDtMib30+GOA=",
+      "dev": true
+    },
     "lodash.mergewith": {
       "version": "4.6.1",
       "resolved": "https://registry.npmjs.org/lodash.mergewith/-/lodash.mergewith-4.6.1.tgz",
@@ -7399,6 +7405,18 @@
         }
       }
     },
+    "object.entries": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/object.entries/-/object.entries-1.0.4.tgz",
+      "integrity": "sha1-G/mk3SKI9bM/Opk9JXZh8F0WGl8=",
+      "dev": true,
+      "requires": {
+        "define-properties": "^1.1.2",
+        "es-abstract": "^1.6.1",
+        "function-bind": "^1.1.0",
+        "has": "^1.0.1"
+      }
+    },
     "object.getownpropertydescriptors": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/object.getownpropertydescriptors/-/object.getownpropertydescriptors-2.0.3.tgz",
@@ -7870,6 +7888,34 @@
       "resolved": "https://registry.npmjs.org/preact/-/preact-8.3.1.tgz",
       "integrity": "sha512-s8H1Y8O9e+mOBo3UP1jvWqArPmjCba2lrrGLlq/0kN1XuIINUbYtf97iiXKxCuG3eYwmppPKnyW2DBrNj/TuTg==",
       "dev": true
+    },
+    "preact-render-spy": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/preact-render-spy/-/preact-render-spy-1.3.0.tgz",
+      "integrity": "sha512-6gdi9mCMlhNPv4JRoQNSKu2kEbhStfJT/bN+n3gb/NwGKNmFg9q8eac9qFTSCswsOWmkdDk2WJiUoHZImIPSyA==",
+      "dev": true,
+      "requires": {
+        "lodash.isequal": "^4.5.0",
+        "object.entries": "^1.0.4",
+        "preact-render-to-string": "^3.6.3"
+      }
+    },
+    "preact-render-to-string": {
+      "version": "3.8.2",
+      "resolved": "https://registry.npmjs.org/preact-render-to-string/-/preact-render-to-string-3.8.2.tgz",
+      "integrity": "sha512-przuZPajiurStGgxMoJP0EJeC4xj5CgHv+M7GfF3YxAdhGgEWAkhOSE0xympAFN20uMayntBZpttIZqqLl77fw==",
+      "dev": true,
+      "requires": {
+        "pretty-format": "^3.5.1"
+      },
+      "dependencies": {
+        "pretty-format": {
+          "version": "3.8.0",
+          "resolved": "http://registry.npmjs.org/pretty-format/-/pretty-format-3.8.0.tgz",
+          "integrity": "sha1-v77VbV6ad2ZF9LH/eqGjrE+jw4U=",
+          "dev": true
+        }
+      }
     },
     "prelude-ls": {
       "version": "1.1.2",

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "mqtt": "^2.18.3",
     "node-sass": "^4.9.4",
     "preact": "^8.3.1",
+    "preact-render-spy": "^1.3.0",
     "prettier": "^1.14.3",
     "regenerator-runtime": "^0.12.1",
     "sass-loader": "^7.1.0",

--- a/test/components/NumericValue.test.js
+++ b/test/components/NumericValue.test.js
@@ -1,0 +1,20 @@
+import { h } from "preact"
+import { shallow } from "preact-render-spy"
+import NumericValue from "../../src/app/components/NumericValue"
+
+describe("Number display", () => {
+  it("shows dashes when no value given", () => {
+    const context = shallow(<NumericValue />)
+    expect(context.find("p").text()).toBe("--")
+  })
+
+  it("displays 0 values", () => {
+    const context = shallow(<NumericValue value={0} />)
+    expect(context.find("p").text()).toBe("0")
+  })
+
+  it("adds a unit to the value passed", () => {
+    const context = shallow(<NumericValue value={123} unit="A" />)
+    expect(context.find("p").text()).toBe("123A")
+  })
+})


### PR DESCRIPTION
I've researched a lot of options for unit testing with Preact.
The documentation is rather scattered and there isn't "one" recommended way to do unit testing:
* https://preactjs.com/guide/unit-testing-with-enzyme -> example using Karma instead of Jest
* https://gist.github.com/philmander/29eb95e7992eb360ed7f537ea29db17b -> nice that it allows shallow rendering, but it's just a gist -> don't want to add custom testing code in our codebase
* https://github.com/developit/preact/issues/658 -> several other approaches described; this is where I got the tip about `preact-render-spy`; most approaches require manually mounting the components -> a lot of ceremony for writing a test vs just saying `shallow` or `mount`

Since our needs are rather basic, I decided to finally go with [preact-render-spy](https://www.npmjs.com/package/preact-render-spy) because of the ease of setting it up & basic support for shallow rendering & deep shallow rendering; 
Also added an example unit test for the `NumericValue` component.

