### PR TITLE
Handle device disconnects

### DIFF
--- a/scripts/fake-broker.js
+++ b/scripts/fake-broker.js
@@ -12,20 +12,22 @@ const EU_PRODUCT_ID = 9760
 
 const randomlyChangingPaths = [
   "N/mockPortalId/system/0/Dc/Battery/Voltage",
+  "N/mockPortalId/system/0/Dc/Battery/Current",
+  "N/mockPortalId/system/0/Dc/Battery/Power",
+  "N/mockPortalId/system/0/Dc/Battery/Soc",
+  "N/mockPortalId/system/0/Dc/Battery/TimeToGo",
   "N/mockPortalId/vebus/257/Ac/ActiveIn/L1/V",
   "N/mockPortalId/vebus/257/Ac/ActiveIn/L2/V",
   "N/mockPortalId/vebus/257/Ac/ActiveIn/L3/V",
   "N/mockPortalId/vebus/257/Ac/Out/L1/V",
   "N/mockPortalId/vebus/257/Ac/Out/L2/V",
   "N/mockPortalId/vebus/257/Ac/Out/L3/V",
-  "N/mockPortalId/system/0/Dc/Battery/Current",
   "N/mockPortalId/vebus/257/Ac/ActiveIn/L1/I",
   "N/mockPortalId/vebus/257/Ac/ActiveIn/L2/I",
   "N/mockPortalId/vebus/257/Ac/ActiveIn/L3/I",
   "N/mockPortalId/vebus/257/Ac/Out/L1/I",
   "N/mockPortalId/vebus/257/Ac/Out/L2/I",
   "N/mockPortalId/vebus/257/Ac/Out/L3/I",
-  "N/mockPortalId/system/0/Dc/Battery/Power",
   "N/mockPortalId/system/0/Dc/System/Power",
   "N/mockPortalId/vebus/257/Ac/ActiveIn/L1/P",
   "N/mockPortalId/vebus/257/Ac/ActiveIn/L2/P",
@@ -33,8 +35,6 @@ const randomlyChangingPaths = [
   "N/mockPortalId/system/0/Ac/ConsumptionOnOutput/L1/Power",
   "N/mockPortalId/system/0/Ac/ConsumptionOnOutput/L2/Power",
   "N/mockPortalId/system/0/Ac/ConsumptionOnOutput/L3/Power",
-  "N/mockPortalId/system/0/Dc/Battery/Soc",
-  "N/mockPortalId/system/0/Dc/Battery/TimeToGo",
   "N/mockPortalId/system/0/Dc/Pv/Power",
   "N/mockPortalId/system/0/Dc/Pv/Current"
 ]
@@ -67,6 +67,11 @@ export class MockMQQTBroker {
     this.server.on("clientConnected", () => {
       clearInterval(this.intervalRef)
       this.intervalRef = setInterval(this.sendRandomValues, 3000)
+      setTimeout(() => {
+        this.sendNull("N/mockPortalId/system/0/Dc/Battery/Voltage")
+        this.sendNull("N/mockPortalId/system/0/Dc/Battery/Current")
+        this.sendNull("N/mockPortalId/system/0/Dc/Battery/Power")
+      }, 5000)
     })
 
     this.server.on("published", packet => {
@@ -83,6 +88,17 @@ export class MockMQQTBroker {
     var message = {
       topic: path,
       payload: JSON.stringify({ value: value || {} }),
+      qos: 0,
+      retain: false
+    }
+
+    this.server.publish(message)
+  }
+
+  sendNull = path => {
+    var message = {
+      topic: path,
+      payload: JSON.stringify({ value: null }),
       qos: 0,
       retain: false
     }

--- a/src/app/components/AcLoads.js
+++ b/src/app/components/AcLoads.js
@@ -23,41 +23,54 @@ const getTopics = (portalId, vebusInstanceId) => {
   }
 }
 
-const AcLoads = props => {
-  const [voltagePhase1] = props.voltage || []
+const AcLoadsContainer = props => {
   return (
     <div className="metric metric--small">
       <img src={require("../../images/icons/ac.svg")} className="metric__icon" />
       <div className="metric__value-container">
         <p className="text text--medium">AC Loads</p>
-        {props.loading ? (
-          <div className="metric__values">Loading...</div>
-        ) : (
-          <div className="metric__values">
-            <NumericValue value={voltagePhase1.value} unit="V" />
-            <NumericValue value={phaseSum(props.current)} unit="A" precision={1} />
-            <NumericValue value={phaseSum(props.power)} unit={"W"} />
-          </div>
-        )}
+        <div className="metric__values">{props.children}</div>
       </div>
     </div>
+  )
+}
+
+const AcLoads = props => {
+  const [voltagePhase1] = props.voltage
+  return (
+    <AcLoadsContainer>
+      <NumericValue value={voltagePhase1 ? voltagePhase1.value : null} unit="V" />
+      <NumericValue value={phaseSum(props.current)} unit="A" precision={1} />
+      <NumericValue value={phaseSum(props.power)} unit={"W"} />
+    </AcLoadsContainer>
+  )
+}
+
+const AcLoadsLoading = () => {
+  return (
+    <AcLoadsContainer>
+      <NumericValue value={null} />
+      <NumericValue value={null} />
+      <NumericValue value={null} />
+    </AcLoadsContainer>
   )
 }
 
 class AcLoadsWithData extends Component {
   render() {
     const { portalId, vebusInstanceId } = this.props
-    if (!portalId) {
-      return <AcLoads loading />
+    if (!vebusInstanceId) {
+      return <AcLoadsLoading />
+    } else {
+      return (
+        <MqttSubscriptions topics={getTopics(portalId, vebusInstanceId)}>
+          {topics => {
+            const { current, voltage, power } = topics
+            return <AcLoads current={current} voltage={voltage} power={power} />
+          }}
+        </MqttSubscriptions>
+      )
     }
-    return (
-      <MqttSubscriptions topics={getTopics(portalId, vebusInstanceId)}>
-        {topics => {
-          const { current, voltage, power } = topics
-          return <AcLoads current={current} voltage={voltage} power={power} />
-        }}
-      </MqttSubscriptions>
-    )
   }
 }
 

--- a/src/app/components/AcLoads.js
+++ b/src/app/components/AcLoads.js
@@ -24,7 +24,7 @@ const getTopics = (portalId, vebusInstanceId) => {
 }
 
 const AcLoads = props => {
-  const [voltagePhase1] = props.voltage
+  const [voltagePhase1] = props.voltage || []
   return (
     <div className="metric metric--small">
       <img src={require("../../images/icons/ac.svg")} className="metric__icon" />
@@ -47,7 +47,7 @@ const AcLoads = props => {
 class AcLoadsWithData extends Component {
   render() {
     const { portalId, vebusInstanceId } = this.props
-    if (!portalId || !vebusInstanceId) {
+    if (!portalId) {
       return <AcLoads loading />
     }
     return (

--- a/src/app/components/ActiveSource.js
+++ b/src/app/components/ActiveSource.js
@@ -67,7 +67,7 @@ class ActiveSource extends Component {
     const [voltagePhase1] = this.props.voltage
 
     if (activeSource === undefined) {
-      return <ActiveSourceMetric title={"..."} icon={require("../../images/icons/shore-power.svg")} />
+      return <ActiveSourceMetric title={"--"} icon={require("../../images/icons/shore-power.svg")} />
     }
 
     if (activeSource === null) {
@@ -120,10 +120,6 @@ const ActiveSourceMetric = props => {
 class ActiveSourceWithData extends Component {
   render() {
     const { portalId, vebusInstanceId } = this.props
-    if (!portalId || !vebusInstanceId) {
-      return <div>Loading...</div>
-    }
-
     return (
       <MqttSubscriptions topics={getTopics(portalId, vebusInstanceId)}>
         {topics => {

--- a/src/app/components/ActiveSource.js
+++ b/src/app/components/ActiveSource.js
@@ -68,21 +68,19 @@ class ActiveSource extends Component {
 
     if (activeSource === undefined) {
       return <ActiveSourceMetric title={"--"} icon={require("../../images/icons/shore-power.svg")} />
-    }
-
-    if (activeSource === null) {
+    } else if (activeSource === null) {
       return <NoActiveSource />
+    } else {
+      return (
+        <ActiveSourceMetric
+          title={this.activeSourceLabel[activeSource]}
+          icon={this.activeSourceIcon[activeSource]}
+          voltage={voltagePhase1.value}
+          current={phaseSum(this.props.current)}
+          power={phaseSum(this.props.power)}
+        />
+      )
     }
-
-    return (
-      <ActiveSourceMetric
-        title={this.activeSourceLabel[activeSource]}
-        icon={this.activeSourceIcon[activeSource]}
-        voltage={voltagePhase1.value}
-        current={phaseSum(this.props.current)}
-        power={phaseSum(this.props.power)}
-      />
-    )
   }
 }
 
@@ -120,21 +118,25 @@ const ActiveSourceMetric = props => {
 class ActiveSourceWithData extends Component {
   render() {
     const { portalId, vebusInstanceId } = this.props
-    return (
-      <MqttSubscriptions topics={getTopics(portalId, vebusInstanceId)}>
-        {topics => {
-          return (
-            <ActiveSource
-              activeInput={topics.activeInput}
-              settings={topics.settings}
-              current={topics.current}
-              voltage={topics.voltage}
-              power={topics.power}
-            />
-          )
-        }}
-      </MqttSubscriptions>
-    )
+    if (!vebusInstanceId) {
+      return <NoActiveSource />
+    } else {
+      return (
+        <MqttSubscriptions topics={getTopics(portalId, vebusInstanceId)}>
+          {topics => {
+            return (
+              <ActiveSource
+                activeInput={topics.activeInput}
+                settings={topics.settings}
+                current={topics.current}
+                voltage={topics.voltage}
+                power={topics.power}
+              />
+            )
+          }}
+        </MqttSubscriptions>
+      )
+    }
   }
 }
 

--- a/src/app/components/Battery/Battery.js
+++ b/src/app/components/Battery/Battery.js
@@ -36,7 +36,7 @@ const secondaryBatteries = (instances, mainBatteryInstance, portalId) => {
   return instancesWithChannels.map(([instance, channel, index]) => {
     return (
       <MqttSubscriptions
-        key={instance + channel}
+        key={`battery-${index}-channel-${channel}`}
         topics={{
           voltage: `N/${portalId}/battery/${instance}/Dc/${channel}/Voltage`,
           current: `N/${portalId}/battery/${instance}/Dc/${channel}/Current`,
@@ -44,7 +44,7 @@ const secondaryBatteries = (instances, mainBatteryInstance, portalId) => {
         }}
       >
         {topics => {
-          if (topics.voltage.value || topics.current.value || topics.power.value)
+          if (topics.voltage.value || topics.current.value || topics.power.value) {
             return (
               <div className="metric__values">
                 <BatteryName
@@ -58,6 +58,7 @@ const secondaryBatteries = (instances, mainBatteryInstance, portalId) => {
                 <NumericValue value={topics.power.value} unit="W" />
               </div>
             )
+          }
         }}
       </MqttSubscriptions>
     )

--- a/src/app/components/DcLoads/DcLoads.js
+++ b/src/app/components/DcLoads/DcLoads.js
@@ -19,7 +19,11 @@ export const DcLoads = props => {
         <div className="metric__values">
           {props.hasDcSystem !== 0 ? (
             <>
-              <NumericValue value={props.voltage ? props.power / props.voltage : undefined} unit="A" precision={1} />
+              <NumericValue
+                value={props.voltage && props.power ? props.power / props.voltage : undefined}
+                unit="A"
+                precision={1}
+              />
               <NumericValue value={props.power} unit="W" />
             </>
           ) : (

--- a/src/app/components/ShoreInputLimit/ShoreInputLimit.js
+++ b/src/app/components/ShoreInputLimit/ShoreInputLimit.js
@@ -38,9 +38,9 @@ const ShoreInputLimit = props => {
         onChangeShoreInputLimitClicked={props.onChangeShoreInputLimitClicked}
       />
     )
+  } else {
+    return <ReadOnlyShoreInputLimit currentLimit={props.currentLimit} />
   }
-
-  return <ReadOnlyShoreInputLimit currentLimit={props.currentLimit} />
 }
 
 const MetricSmallLoading = props => (
@@ -54,38 +54,37 @@ const MetricSmallLoading = props => (
 class ShoreInputLimitWithData extends Component {
   render() {
     const { portalId, vebusInstanceId } = this.props
-    if (!portalId && !vebusInstanceId) {
-      return <MetricSmallLoading />
+    if (!vebusInstanceId) {
+      return <ReadOnlyShoreInputLimit currentLimit={"--"} />
+    } else {
+      return (
+        <GetShorePowerInputNumber portalId={portalId}>
+          {shorePowerInput => {
+            if (shorePowerInput === undefined) {
+              return <MetricSmallLoading />
+            } else if (shorePowerInput === null) {
+              return (
+                <MetricSmallLoading message="No shore power configured. Please check 'Remote Console > Settings > System setup > AC input'" />
+              )
+            } else {
+              return (
+                <MqttSubscriptions topics={getTopics(portalId, vebusInstanceId, shorePowerInput)}>
+                  {topics => {
+                    return (
+                      <ShoreInputLimit
+                        currentLimit={formatNumber({ value: topics.currentLimit.value, unit: "A" })}
+                        isAdjustable={topics.currentLimitIsAdjustable.value && this.props.connected}
+                        onChangeShoreInputLimitClicked={this.props.onChangeShoreInputLimitClicked}
+                      />
+                    )
+                  }}
+                </MqttSubscriptions>
+              )
+            }
+          }}
+        </GetShorePowerInputNumber>
+      )
     }
-    return (
-      <GetShorePowerInputNumber portalId={portalId}>
-        {shorePowerInput => {
-          if (shorePowerInput === undefined) {
-            return <MetricSmallLoading />
-          }
-
-          if (shorePowerInput === null) {
-            return (
-              <MetricSmallLoading message="No shore power configured. Please check 'Remote Console > Settings > System setup > AC input'" />
-            )
-          }
-
-          return (
-            <MqttSubscriptions topics={getTopics(portalId, vebusInstanceId, shorePowerInput)}>
-              {topics => {
-                return (
-                  <ShoreInputLimit
-                    currentLimit={formatNumber({ value: topics.currentLimit.value, unit: "A" })}
-                    isAdjustable={topics.currentLimitIsAdjustable.value && this.props.connected}
-                    onChangeShoreInputLimitClicked={this.props.onChangeShoreInputLimitClicked}
-                  />
-                )
-              }}
-            </MqttSubscriptions>
-          )
-        }}
-      </GetShorePowerInputNumber>
-    )
   }
 }
 export default ShoreInputLimitWithData

--- a/src/app/index.js
+++ b/src/app/index.js
@@ -68,10 +68,6 @@ class App extends Component {
                 return (
                   <GetVebusDeviceInstance>
                     {vebusInstanceId => {
-                      if (!vebusInstanceId) {
-                        console.warn("No VE.Bus instance id yet ...")
-                        return <Connecting />
-                      }
                       return (
                         <div className="main__container">
                           <Header

--- a/src/app/utils/util.js
+++ b/src/app/utils/util.js
@@ -33,14 +33,12 @@ export const parseTopic = topic => {
 }
 
 export const getMessageJson = message => {
-  let data
   try {
-    data = JSON.parse(message.toString())
+    return JSON.parse(message.toString())
   } catch (e) {
-    data = {}
-    Logger.error("Could not parse message: ", message.toString(), e)
+    Logger.error("Could not parse message: ", message.toString())
+    return { value: null }
   }
-  return data
 }
 
 export const getMessageValue = message => {

--- a/src/app/utils/util.js
+++ b/src/app/utils/util.js
@@ -41,21 +41,6 @@ export const getMessageJson = message => {
   }
 }
 
-export const getMessageValue = message => {
-  const data = getMessageJson(message)
-  return data.value !== undefined ? data.value : null
-}
-
-export const parseMessage = (topic, message) => {
-  let value = getMessageValue(message)
-  const { dbusPath } = parseTopic(topic)
-
-  return {
-    path: dbusPath,
-    value
-  }
-}
-
 export function objectValues(data) {
   return Object.keys(data).map(key => data[key])
 }

--- a/src/app/utils/util.js
+++ b/src/app/utils/util.js
@@ -68,8 +68,8 @@ export const getParameterByName = (name, url) => {
 }
 
 export const phaseSum = phases => {
-  const [phase1, phase2, phase3] = phases || []
-  return phase1.value ? phase1.value + phase2.value + phase3.value : null
+  const [phase1, phase2, phase3] = phases
+  return phase1 && phase1.value ? phase1.value + phase2.value + phase3.value : null
 }
 
 export const flatten = arrays => {

--- a/test/util.test.js
+++ b/test/util.test.js
@@ -1,4 +1,4 @@
-import { parseMessage, parseTopic } from "../src/app/utils/util"
+import { parseTopic } from "../src/app/utils/util"
 
 describe("parseTopic", () => {
   test("splits topic into its parts", () => {
@@ -19,17 +19,5 @@ describe("parseTopic", () => {
       deviceInstance: 0,
       dbusPath: "/CurrentLimit"
     })
-  })
-})
-
-describe("parseMessage", () => {
-  test("correctly extracts value from Buffer message", () => {
-    const result = parseMessage("N/123/Serial", Buffer.from('{ "value": 123 }'))
-    expect(result.value).toEqual(123)
-  })
-
-  test("correctly extracts value 0", () => {
-    const result = parseMessage("N/123/Serial", Buffer.from('{ "value": 0 }'))
-    expect(result.value).toEqual(0)
   })
 })


### PR DESCRIPTION
When devices are disconnected or otherwise are lost from the mqtt,
display dashes in both cases:

- When mqtt message is empty
- message is {value: null}