### PR TITLE
Only show charger control buttons if not disabled

### DIFF
--- a/src/app/components/InverterCharger/InverterCharger.js
+++ b/src/app/components/InverterCharger/InverterCharger.js
@@ -37,6 +37,13 @@ const InverterCharger = ({
 }) => {
   const productNameShort = productName && productName.split(" ")[0]
 
+  function getModeTitle(modeNum) {
+    if (modeNum === 3) return "On"
+    else if (modeNum === 4) return "Off"
+    else if (modeNum === 2) return "Charger only"
+    else return ""
+  }
+
   return (
     <div className="metric charger inverter-charger">
       <GetShorePowerInputNumber portalId={portalId}>
@@ -48,7 +55,7 @@ const InverterCharger = ({
               <HeaderView
                 icon={require("../../../images/icons/multiplus.svg")}
                 title={customName || `Inverter / Charger: ${productNameShort}`}
-                subTitle={systemStateFormatter(state)}
+                subTitle={`${getModeTitle(mode)} - ${systemStateFormatter(state)}  `}
                 child
               />
               <InputLimit
@@ -61,25 +68,19 @@ const InverterCharger = ({
           )
         }}
       </GetShorePowerInputNumber>
-      <div className="charger__mode-selector">
-        <SelectorButton disabled={!modeIsAdjustable} active={mode === 3} onClick={() => onModeSelected(SYSTEM_MODE.ON)}>
-          On
-        </SelectorButton>
-        <SelectorButton
-          disabled={!modeIsAdjustable}
-          active={mode === 4}
-          onClick={() => onModeSelected(SYSTEM_MODE.OFF)}
-        >
-          Off
-        </SelectorButton>
-        <SelectorButton
-          disabled={!modeIsAdjustable}
-          active={mode === 1}
-          onClick={() => onModeSelected(SYSTEM_MODE.CHARGER_ONLY)}
-        >
-          Charger only
-        </SelectorButton>
-      </div>
+      {!!modeIsAdjustable && (
+        <div className="charger__mode-selector">
+          <SelectorButton active={mode === 3} onClick={() => onModeSelected(SYSTEM_MODE.ON)}>
+            {getModeTitle(3)}
+          </SelectorButton>
+          <SelectorButton active={mode === 4} onClick={() => onModeSelected(SYSTEM_MODE.OFF)}>
+            {getModeTitle(4)}
+          </SelectorButton>
+          <SelectorButton active={mode === 1} onClick={() => onModeSelected(SYSTEM_MODE.CHARGER_ONLY)}>
+            {getModeTitle(1)}
+          </SelectorButton>
+        </div>
+      )}
     </div>
   )
 }

--- a/src/app/components/InverterCharger/InverterCharger.js
+++ b/src/app/components/InverterCharger/InverterCharger.js
@@ -55,7 +55,7 @@ const InverterCharger = ({
               <HeaderView
                 icon={require("../../../images/icons/multiplus.svg")}
                 title={customName || `Inverter / Charger: ${productNameShort}`}
-                subTitle={`${getModeTitle(mode)} - ${systemStateFormatter(state)}  `}
+                subTitle={(!modeIsAdjustable ? getModeTitle(mode) + " - " : "") + systemStateFormatter(state)}
                 child
               />
               <InputLimit

--- a/src/app/components/InverterCharger/InverterCharger.js
+++ b/src/app/components/InverterCharger/InverterCharger.js
@@ -40,7 +40,7 @@ const InverterCharger = ({
   function getModeTitle(modeNum) {
     if (modeNum === 3) return "On"
     else if (modeNum === 4) return "Off"
-    else if (modeNum === 2) return "Charger only"
+    else if (modeNum === 1) return "Charger only"
     else return ""
   }
 


### PR DESCRIPTION
Instead of showing the charger status on 'disabled controls', show it as text in the header. (Issue https://github.com/victronenergy/venus-html5-app/issues/109)

Previous:
![prev](https://user-images.githubusercontent.com/9929190/93333811-2ca8ea00-f824-11ea-9707-0d6345e2e34d.png)

New:
<img width="660" alt="Screenshot 2020-09-16 at 12 21 34" src="https://user-images.githubusercontent.com/9929190/93333577-cd4ada00-f823-11ea-8018-1915ecc051d2.png">
