### PR TITLE
105 no lock without mqtt

### DIFF
--- a/src/app/components/App.js
+++ b/src/app/components/App.js
@@ -40,7 +40,6 @@ class App extends Component {
     viewUnmounting: false,
     currentPage: 0,
     pages: 1,
-    showLockButton: true,
     screenLocked: localStorage.getItem("screenLocked") === "true",
     toggleLock: this.toggleLock
   }
@@ -102,7 +101,7 @@ class App extends Component {
               <LockContext.Provider
                 value={{
                   screenLocked: this.state.screenLocked,
-                  toggleLocked: this.toggleLocked
+                  showLockButton: false
                 }}
               >
                 <>
@@ -146,7 +145,8 @@ class App extends Component {
                             <LockContext.Provider
                               value={{
                                 screenLocked: this.state.screenLocked,
-                                toggleLocked: this.toggleLocked
+                                toggleLocked: this.toggleLocked,
+                                showLockButton: true
                               }}
                             >
                               <>

--- a/src/app/components/App.js
+++ b/src/app/components/App.js
@@ -97,7 +97,6 @@ class App extends Component {
       <MqttClientProvider host={host} port={port}>
         {(_, isConnected, error) => {
           if (error) {
-            this.setState({ screenLocked: false })
             return (
               <LockContext.Provider
                 value={{

--- a/src/app/components/App.js
+++ b/src/app/components/App.js
@@ -97,6 +97,7 @@ class App extends Component {
       <MqttClientProvider host={host} port={port}>
         {(_, isConnected, error) => {
           if (error) {
+            this.setState({ screenLocked: false })
             return (
               <LockContext.Provider
                 value={{

--- a/src/app/components/App.js
+++ b/src/app/components/App.js
@@ -108,7 +108,6 @@ class App extends Component {
                   <HeaderWithoutMQTTData
                     handleRemoteConsoleButtonClicked={this.toggleRemoteConsole}
                     handleLockScreenButtonClicked={this.toggleLock}
-                    screenLocked={this.state.screenLocked}
                     currentView={this.state.currentView}
                   />
                   {(() => {

--- a/src/app/components/Header/Header.js
+++ b/src/app/components/Header/Header.js
@@ -12,7 +12,6 @@ export const Header = props => {
     currentView,
     handleRemoteConsoleButtonClicked,
     handleLockScreenButtonClicked,
-    screenLocked,
     showLockButton,
     setPage,
     currentPage,
@@ -29,7 +28,6 @@ export const Header = props => {
         <div className="header-button-container">
           <LockButtonHeader
             onClick={handleLockScreenButtonClicked}
-            screenLocked={screenLocked}
             currentView={currentView}
             header={true}
             showLockButton={showLockButton}
@@ -78,7 +76,6 @@ class HeaderWithData extends Component {
       currentView,
       handleRemoteConsoleButtonClicked,
       handleLockScreenButtonClicked,
-      screenLocked,
       setPage,
       currentPage,
       pages
@@ -91,7 +88,6 @@ class HeaderWithData extends Component {
               showRemoteConsoleSetting={!!topics.showRemoteConsoleSetting}
               handleRemoteConsoleButtonClicked={handleRemoteConsoleButtonClicked}
               handleLockScreenButtonClicked={handleLockScreenButtonClicked}
-              screenLocked={screenLocked}
               currentView={currentView}
               setPage={setPage}
               currentPage={currentPage}
@@ -106,13 +102,12 @@ class HeaderWithData extends Component {
 
 class HeaderWithoutMQTTData extends Component {
   render() {
-    const { currentView, handleRemoteConsoleButtonClicked, handleLockScreenButtonClicked, screenLocked } = this.props
+    const { currentView, handleRemoteConsoleButtonClicked, handleLockScreenButtonClicked } = this.props
     return (
       <Header
         showRemoteConsoleSetting={true}
         handleRemoteConsoleButtonClicked={handleRemoteConsoleButtonClicked}
         handleLockScreenButtonClicked={handleLockScreenButtonClicked}
-        screenLocked={screenLocked}
         currentView={currentView}
         showLockButton={false}
       />

--- a/src/app/components/Header/Header.js
+++ b/src/app/components/Header/Header.js
@@ -13,6 +13,7 @@ export const Header = props => {
     handleRemoteConsoleButtonClicked,
     handleLockScreenButtonClicked,
     screenLocked,
+    showLockButton,
     setPage,
     currentPage,
     pages
@@ -31,6 +32,7 @@ export const Header = props => {
             screenLocked={screenLocked}
             currentView={currentView}
             header={true}
+            showLockButton={showLockButton}
           />
 
           {showRemoteConsoleSetting && (
@@ -112,6 +114,7 @@ class HeaderWithoutMQTTData extends Component {
         handleLockScreenButtonClicked={handleLockScreenButtonClicked}
         screenLocked={screenLocked}
         currentView={currentView}
+        showLockButton={false}
       />
     )
   }

--- a/src/app/components/LockButton/LockButton.js
+++ b/src/app/components/LockButton/LockButton.js
@@ -6,8 +6,8 @@ import "./LockButton.scss"
 
 class LockButtonHeader extends Component {
   render() {
-    const { currentView, header } = this.props
-    return <LockButton currentView={currentView} header={header} />
+    const { currentView, header, showLockButton } = this.props
+    return <LockButton currentView={currentView} header={header} showLockButton={showLockButton} />
   }
 }
 
@@ -20,11 +20,14 @@ class LockButtonFooter extends Component {
 }
 
 class LockButton extends Component {
+  static defaultProps = {
+    showLockButton: true
+  }
   render() {
-    const { currentView, header } = this.props
+    const { currentView, header, showLockButton } = this.props
     return (
       <>
-        {currentView === VIEWS.METRICS && (
+        {currentView === VIEWS.METRICS && showLockButton && (
           <LockContext.Consumer>
             {context => (
               <div

--- a/src/app/contexts.js
+++ b/src/app/contexts.js
@@ -3,7 +3,6 @@ import React from "react"
 export const MqttClientContext = React.createContext(null)
 
 export const LockContext = React.createContext({
-  showLockButton: true,
   screenLocked: localStorage.getItem("screenLocked"),
   toggleLocked: () => {}
 })


### PR DESCRIPTION
Do not show the lockButton if no MQTT data is available, and set `screenLocked` to false.

**Q: Why not use the same logic as for hiding the button in remote console view, and why do the footer and header buttons use different logic?** 
A: Ah, that's because of how the App is structured. The header button lives in the header, which is still rendered if no data is available in `App.js`, as HeaderWithoutMQTTData.
Whereas the button in the footer is a completely seperate component in `App.js`, which we can simply not render if no data is available. 
The LockButton component from which both the Footer and Header version inherit, renders `currentView === VIEWS.METRICS`, and so in Remote Console View, both the Footer and Header version are being taken care of.