### PR TITLE
Fix run on nodejs v17 and higher

### DIFF
--- a/node-options.sh
+++ b/node-options.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+# TODO: this code can be removed after migrating to webpack v5
+# Introduced in Node.js v17 alongside support for OpenSSL 3.0, the --openssl-legacy-provider
+# flag tells Node.js to revert to OpenSSL 3.0's legacy provider. This allows to run webpack v4
+# that still create hashes with legacy cryptographic algorithms like MD4.
+
+# Get only major number of Node.js version
+VERSION=`node -v | while IFS=. read a b; do echo "$a"; done | grep -o -E "\d*"`
+
+# Apply --openssl-legacy-provider option only for node v17 and higher
+if [ $VERSION -gt "16" ]
+then
+  export NODE_OPTIONS=--openssl-legacy-provider
+fi

--- a/package.json
+++ b/package.json
@@ -129,8 +129,8 @@
   },
   "scripts": {
     "clean": "rm -rf build",
-    "start": "node scripts/start.js",
-    "build": "GENERATE_SOURCEMAP=false node scripts/build.js",
+    "start": ". ./node-options.sh && node scripts/start.js",
+    "build": ". ./node-options.sh && GENERATE_SOURCEMAP=false node scripts/build.js",
     "test": "node scripts/test.js --transformIgnorePatterns \"node_modules/(?!@elninotech/mfd-modules)/\"",
     "serve": "serve -C -s -l 8000 dist",
     "test:dev": "npm test -- --watchAll=false && npm run cy:run",


### PR DESCRIPTION
## Quick fix that allows `venus-html5-app` run on LTS Node.js v18.x.

### Initial problem and solution workflow

In Node.js v17, the Node.js developers closed a security hole in the SSL provider. This fix was a breaking change that corresponded with similar breaking changes in the SSL packages in NPM. When you attempt to use SSL in Node.js v17 or later without also upgrading those SSL packages in the package.json, then you will see the `ERR_OSSL_EVP_UNSUPPORTED` error.

I found that the problem is caused only by the webpack `babel-loader` plugin which uses an old `md4` algorithm to generate chunk hashes `crypto.createHash(‘md4)`. Therefore forcing Node.js to use `-openssl-legacy-provider` doesn’t affect the security of the `venus-html5-app` itself.

### Further actions

I opened the [separate PR](https://github.com/victronenergy/venus-html5-app/pull/206) (in progress) to upgrade `venus-html5-app` dependencies to the latest versions, but it requires additional work and testing as a number of breaking changes are applied to the new webpack v5 and its ecosystem. At the moment we can use the solution in this PR as a workaround while we’re working on bumping the whole dependencies stack.
