### PR TITLE
Batteries: Add missing styling and remove pathLength attribute

### DIFF
--- a/src/app/Marine2/components/ui/ProgressCircle/ProgressCircle.tsx
+++ b/src/app/Marine2/components/ui/ProgressCircle/ProgressCircle.tsx
@@ -4,14 +4,21 @@ import { colorForPercentageFormatter } from "../../../utils/formatters"
 const ProgressCircle = ({ percentage, children }: Props) => {
   const hasPercentage = percentage !== null
   const roundedPercentage = Math.round(percentage)
-  const color = hasPercentage ? colorForPercentageFormatter(roundedPercentage) : "victron-gray-4"
+  const color = hasPercentage ? colorForPercentageFormatter(roundedPercentage) : "victron-gray-400"
   const strokeClasses = classNames("fill-none stroke-16", {
     "stroke-victron-green dark:stroke-victron-green-dark": color === "victron-green",
     "stroke-victron-yellow dark:stroke-victron-yellow-dark": color === "victron-yellow",
     "stroke-victron-red dark:stroke-victron-red-dark": color === "victron-red",
     "stroke-victron-blue dark:stroke-victron-blue-dark": color === "victron-blue",
-    "stroke-victron-gray dark:stroke-victron-gray-4-dark": color === "victron-gray-4",
+    "stroke-victron-gray-400 dark:stroke-victron-gray-dark": color === "victron-gray-400",
   })
+
+  // Due to the pathLength attribute not working on some device, we need to calculate some values.
+  const circleRadius = 111
+  const circlePathLength = 2 * Math.PI * circleRadius
+  const circleStrokeLength = hasPercentage
+    ? (Math.floor(roundedPercentage / 5) * 5 * circlePathLength) / 100
+    : circlePathLength
 
   return (
     <div
@@ -20,16 +27,15 @@ const ProgressCircle = ({ percentage, children }: Props) => {
       }
     >
       <svg className={"absolute w-full h-full -rotate-90"} viewBox={"0 0 238 238"}>
-        <circle r={"111"} cx={"50%"} cy={"50%"} className={classNames("opacity-30", strokeClasses)} />
+        <circle r={circleRadius} cx={"50%"} cy={"50%"} className={classNames("opacity-30", strokeClasses)} />
         {roundedPercentage !== 0 && (
           <circle
-            r={"111"}
+            r={circleRadius}
             cx={"50%"}
             cy={"50%"}
-            strokeDasharray={`${hasPercentage ? Math.floor(roundedPercentage / 5) : 20} 20`}
+            strokeDasharray={`${circleStrokeLength} ${circlePathLength}`}
             strokeDashoffset={0}
             strokeLinecap={"round"}
-            pathLength={20}
             className={strokeClasses}
             style={{ transition: "stroke-dasharray .5s ease" }}
           />

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -31,6 +31,7 @@ module.exports = {
           gray: {
             DEFAULT: "#969591",
             dark: "#969591",
+            "400": '#64635F',
           },
           blue: {
             DEFAULT: "#387DC5",
@@ -60,6 +61,10 @@ module.exports = {
             DEFAULT: "#7F7F9C",
             dark: "#7F7F9C",
           },
+          yellow: {
+            DEFAULT: '#F0962E',
+            dark: '#F0962E',
+          }
         },
       },
       fontFamily: {


### PR DESCRIPTION
This fixes the the broken battery circles on the Garmin screen. Check on the others as well, looks correct now.