### PR TITLE
Add component size breakpoints

### DIFF
--- a/src/app/Marine2/components/boxes/Battery/Battery.tsx
+++ b/src/app/Marine2/components/boxes/Battery/Battery.tsx
@@ -1,13 +1,29 @@
 import Box from "../../ui/Box"
 import { Battery as BatteryType } from "@elninotech/mfd-modules"
-import { batteryStateNameFormatter } from "../../../utils/formatters"
+import { batteryStateNameFormatter, colorForPercentageFormatter } from "../../../utils/formatters"
 import { BATTERY } from "../../../utils/constants"
 import BatteryChargingIcon from "../../../images/icons/battery-charging.svg"
 import BatteryIcon from "../../../images/icons/battery.svg"
 import BatteryDischargingIcon from "../../../images/icons/battery-discharging.svg"
-import { colorForPercentageFormatter } from "../../../utils/formatters"
 import { translate } from "react-i18nify"
 import classNames from "classnames"
+import { applyStyles, StylesType } from "app/Marine2/utils/media"
+import { useState } from "react"
+
+const styles: StylesType = {
+  "sm-s": {
+    mainValue: "text-2xl",
+    subValue: "text-base",
+  },
+  "md-s": {
+    mainValue: "text-3xl",
+    subValue: "text-base",
+  },
+  "lg-s": {
+    mainValue: "text-3xl",
+    subValue: "text-lg",
+  },
+}
 
 const Battery = ({ battery, mode = "compact" }: Props) => {
   const hasPercentage = battery.soc !== undefined && battery.soc !== null
@@ -19,7 +35,8 @@ const Battery = ({ battery, mode = "compact" }: Props) => {
     "text-victron-blue dark:text-victron-blue-dark": color === "victron-blue",
     "text-victron-gray-400 dark:text-victron-gray-dark": color === "victron-gray-400",
   })
-
+  const [boxSize, setBoxSize] = useState<{ width: number; height: number }>({ width: 0, height: 0 })
+  const activeStyles: StylesType = applyStyles(boxSize, styles)
   if (mode === "compact") {
     return (
       <Box icon={batteryStateIconFormatter(battery.state)} title={battery.name}>
@@ -31,48 +48,42 @@ const Battery = ({ battery, mode = "compact" }: Props) => {
   // main batteries (state is charging or discharging)
   if (battery.state !== BATTERY.IDLE) {
     return (
-      <Box icon={batteryStateIconFormatter(battery.state)} title={battery.name} className="truncate">
+      <Box
+      icon={batteryStateIconFormatter(battery.state)}
+      title={battery.name}
+      className="truncate"
+      getBoxSizeCallback={setBoxSize}
+    >
         <div className="w-full h-full flex flex-col">
-          <div className={`${colorClasses} text-2xl md-m:text-3xl lg-l:text-4xl`}>
+          <div className={classNames(`${colorClasses}`, activeStyles?.mainValue)}>
             {Math.round(battery.soc) ?? "--"}
             <span className="opacity-70">%</span>
           </div>
-          <p className="text-base md-m:text-lg lg-l:text-xl text-victron-gray dark:text-victron-gray-dark">
+          <p className={classNames("text-victron-gray dark:text-victron-gray-dark", activeStyles?.subValue)}>
             {batteryStateNameFormatter(translate, battery.state)}
           </p>
-          <p className="text-base md-m:text-lg lg-l:text-xl  text-victron-gray dark:text-victron-gray-dark">
+          <p className={classNames("text-victron-gray dark:text-victron-gray-dark", activeStyles?.subValue)}>
             {battery.temperature ?? "--"}
             <span className="text-victron-gray-400">°C</span>
           </p>
 
-          <div className="w-full h-full flex content-end flex-wrap">
-            <div className="w-full">
-              <div className="my-1 border-[1px] border-victron-gray-200" />
-              <div className="flex justify-between whitespace-nowrap text-victron-gray text-base md-m:text-lg lg-l:text-xl">
-                <p>
-                  {battery.voltage.toFixed(1)} <span className="text-victron-gray-400">V</span>
-                </p>
-                <p>
-                  {battery.current.toFixed(1)} <span className="text-victron-gray-400">A</span>
-                </p>
-                <p>
-                  {battery.power.toFixed(1)} <span className="text-victron-gray-400">W</span>
-                </p>
-              </div>
+        <div className="w-full h-full flex content-end flex-wrap">
+          <div className="w-full">
+            <div className="my-1 border-[1px] border-victron-gray-200" />
+            <div
+              className={classNames("flex justify-between whitespace-nowrap text-victron-gray", activeStyles?.subValue)}
+            >
+              <p>
+                {battery.voltage.toFixed(1)} <span className="text-victron-gray-400">V</span>
+              </p>
+              <p>
+                {battery.current.toFixed(1)} <span className="text-victron-gray-400">A</span>
+              </p>
+              <p>
+                {battery.power.toFixed(1)} <span className="text-victron-gray-400">W</span>
+              </p>
             </div>
           </div>
-        </div>
-      </Box>
-    )
-  }
-
-  // aux batteries (state is idle)
-  return (
-    <Box icon={batteryStateIconFormatter(battery.state)} title={battery.name} className="truncate">
-      <div className="w-full h-full flex flex-col">
-        <div className={`text-black dark:text-white text-2xl md-m:text-3xl lg-l:text-4xl`}>
-          {battery.voltage.toFixed(1)}
-          <span className="opacity-70 text-victron-gray dark:text-victron-gray-dark">V</span>
         </div>
       </div>
     </Box>

--- a/src/app/Marine2/components/boxes/Battery/Battery.tsx
+++ b/src/app/Marine2/components/boxes/Battery/Battery.tsx
@@ -23,6 +23,10 @@ const styles: StylesType = {
     mainValue: "text-3xl",
     subValue: "text-lg",
   },
+  default: {
+    mainValue: "text-xl",
+    subValue: "text-base",
+  },
 }
 
 const Battery = ({ battery, mode = "compact" }: Props) => {
@@ -49,11 +53,11 @@ const Battery = ({ battery, mode = "compact" }: Props) => {
   if (battery.state !== BATTERY.IDLE) {
     return (
       <Box
-      icon={batteryStateIconFormatter(battery.state)}
-      title={battery.name}
-      className="truncate"
-      getBoxSizeCallback={setBoxSize}
-    >
+        icon={batteryStateIconFormatter(battery.state)}
+        title={battery.name}
+        className="truncate"
+        getBoxSizeCallback={setBoxSize}
+      >
         <div className="w-full h-full flex flex-col">
           <div className={classNames(`${colorClasses}`, activeStyles?.mainValue)}>
             {Math.round(battery.soc) ?? "--"}
@@ -67,23 +71,44 @@ const Battery = ({ battery, mode = "compact" }: Props) => {
             <span className="text-victron-gray-400">°C</span>
           </p>
 
-        <div className="w-full h-full flex content-end flex-wrap">
-          <div className="w-full">
-            <div className="my-1 border-[1px] border-victron-gray-200" />
-            <div
-              className={classNames("flex justify-between whitespace-nowrap text-victron-gray", activeStyles?.subValue)}
-            >
-              <p>
-                {battery.voltage.toFixed(1)} <span className="text-victron-gray-400">V</span>
-              </p>
-              <p>
-                {battery.current.toFixed(1)} <span className="text-victron-gray-400">A</span>
-              </p>
-              <p>
-                {battery.power.toFixed(1)} <span className="text-victron-gray-400">W</span>
-              </p>
+          <div className="w-full h-full flex content-end flex-wrap">
+            <div className="w-full">
+              <div className="my-1 border-[1px] border-victron-gray-200" />
+              <div
+                className={classNames(
+                  "flex justify-between whitespace-nowrap text-victron-gray",
+                  activeStyles?.subValue
+                )}
+              >
+                <p>
+                  {battery.voltage.toFixed(1)} <span className="text-victron-gray-400">V</span>
+                </p>
+                <p>
+                  {battery.current.toFixed(1)} <span className="text-victron-gray-400">A</span>
+                </p>
+                <p>
+                  {battery.power.toFixed(1)} <span className="text-victron-gray-400">W</span>
+                </p>
+              </div>
             </div>
           </div>
+        </div>
+      </Box>
+    )
+  }
+
+  // aux batteries (state is idle)
+  return (
+    <Box
+      icon={batteryStateIconFormatter(battery.state)}
+      title={battery.name}
+      className="truncate"
+      getBoxSizeCallback={setBoxSize}
+    >
+      <div className="w-full h-full flex flex-col">
+        <div className={classNames(`text-black dark:text-white`, activeStyles?.mainValue)}>
+          {battery.voltage.toFixed(1)}
+          <span className="text-victron-gray dark:text-victron-gray">V</span>
         </div>
       </div>
     </Box>
@@ -106,7 +131,6 @@ const batteryStateIconFormatter = function (state: number): JSX.Element {
   /* @ts-ignore */
   return <BatteryIcon className={className} />
 }
-
 interface Props {
   battery: BatteryType
   mode?: "compact" | "full"

--- a/src/app/Marine2/components/boxes/EnergyAC/EnergyAC.tsx
+++ b/src/app/Marine2/components/boxes/EnergyAC/EnergyAC.tsx
@@ -1,14 +1,30 @@
-import React from "react"
+import { useState } from "react"
 import Box from "../../../components/ui/Box"
 import { AcLoadsState } from "@elninotech/mfd-modules"
 import ACIcon from "../../../images/icons/ac.svg"
 import { formatPower, formatValue } from "../../../utils/formatters"
 import { translate } from "react-i18nify"
+import { applyStyles, StylesType } from "app/Marine2/utils/media"
+import classNames from "classnames"
+
+const styles: StylesType = {
+  "sm-s": {
+    mainValue: "text-2xl",
+    subValue: "text-base",
+  },
+  "md-s": {
+    mainValue: "text-3xl",
+    subValue: "text-lg",
+  },
+}
 
 const EnergyAC = ({ mode = "compact", acLoads }: Props) => {
   const { current, power, phases, voltage } = acLoads
 
   const totalPower = power.reduce((total, power) => (power ? total + power : total))
+
+  const [boxSize, setBoxSize] = useState<{ width: number; height: number }>({ width: 0, height: 0 })
+  const activeStyles: StylesType = applyStyles(boxSize, styles)
 
   if (mode === "compact") {
     return (
@@ -45,9 +61,10 @@ const EnergyAC = ({ mode = "compact", acLoads }: Props) => {
       /* todo: fix types for svg */
       /* @ts-ignore */
       icon={<ACIcon className={"w-5 text-black dark:text-white"} />}
+      getBoxSizeCallback={setBoxSize}
     >
       <div className="w-full h-full flex flex-col">
-        <div className="text-victron-gray dark:text-white text-2xl md-m:text-3xl lg-l:text-4xl">
+        <div className={classNames("text-victron-gray dark:text-white", activeStyles?.mainValue)}>
           {formatPower(totalPower)}
           <span className="p-0.5 text-victron-gray">{totalPower > 1000 ? "kW" : "W"}</span>
         </div>
@@ -55,7 +72,10 @@ const EnergyAC = ({ mode = "compact", acLoads }: Props) => {
           {Array.from(Array(phases ?? 1).keys()).map((i) => (
             <div
               key={i}
-              className="w-full grid grid-cols-7 md-m:grid-cols-10 text-base md-m:text-lg lg-l:text-xl text-victron-gray dark:text-victron-gray-dark"
+              className={classNames(
+                "w-full grid grid-cols-7 md-m:grid-cols-10 text-victron-gray dark:text-victron-gray-dark",
+                activeStyles?.subValue
+              )}
             >
               <hr className="col-span-10 h-1 border-victron-gray" />
               <p className="col-span-1 text-left">{"L" + (i + 1)}</p>

--- a/src/app/Marine2/components/boxes/EnergyAC/EnergyAC.tsx
+++ b/src/app/Marine2/components/boxes/EnergyAC/EnergyAC.tsx
@@ -16,6 +16,11 @@ const styles: StylesType = {
     mainValue: "text-3xl",
     subValue: "text-lg",
   },
+  // smaller than "sm-s"
+  default: {
+    mainValue: "text-xl",
+    subValue: "text-sm",
+  },
 }
 
 const compactStyles: StylesType = {

--- a/src/app/Marine2/components/boxes/EnergyAC/EnergyAC.tsx
+++ b/src/app/Marine2/components/boxes/EnergyAC/EnergyAC.tsx
@@ -18,32 +18,48 @@ const styles: StylesType = {
   },
 }
 
-const EnergyAC = ({ mode = "compact", acLoads }: Props) => {
+const compactStyles: StylesType = {
+  "sm-s": {
+    name: "text-sm",
+    value: "text-base",
+    namePadding: "pl-2",
+  },
+  "md-s": {
+    name: "text-base",
+    value: "text-lg",
+    namePadding: "pl-3",
+  },
+}
+
+const EnergyAC = ({ mode = "compact", acLoads, compactBoxSize }: Props) => {
   const { current, power, phases, voltage } = acLoads
 
   const totalPower = power.reduce((total, power) => (power ? total + power : total))
 
   const [boxSize, setBoxSize] = useState<{ width: number; height: number }>({ width: 0, height: 0 })
   const activeStyles: StylesType = applyStyles(boxSize, styles)
-
+  let compactActiveStyles: StylesType = {}
+  if (compactBoxSize) {
+    compactActiveStyles = applyStyles(compactBoxSize, compactStyles)
+  }
   if (mode === "compact") {
     return (
-      <div className="flex flex-row justify-between items-center text-sm md-m:text-base lg-l:text-lg">
+      <div className={classNames("flex flex-row justify-between items-center", compactActiveStyles?.name)}>
         <div className="flex items-center">
           {/* todo: fix types for svg */}
           {/* @ts-ignore */}
           <ACIcon className={"w-7 text-black dark:text-white"} />
-          <p className="pl-2 md-m:pl-3">{translate("boxes.acLoads")}</p>
+          <p className={classNames(compactActiveStyles?.namePadding)}>{translate("boxes.acLoads")}</p>
         </div>
         <div>
           {(phases ?? 1) === 1 && (
-            <p className="text-base md:text-xl lg:text-2xl">
+            <p className={classNames(compactActiveStyles?.value)}>
               {formatValue(current[0])}
               <span className="p-0.5 text-victron-gray dark:text-victron-gray-dark">A</span>
             </p>
           )}
           {(phases ?? 1) !== 1 && (
-            <p className="text-base md:text-xl lg:text-2xl">
+            <p className={classNames(compactActiveStyles?.value)}>
               {formatPower(totalPower)}
               <span className="p-0.5 text-victron-gray dark:text-victron-gray-dark">
                 {totalPower > 1000 ? "kW" : "W"}
@@ -102,6 +118,7 @@ const EnergyAC = ({ mode = "compact", acLoads }: Props) => {
 interface Props {
   acLoads: AcLoadsState
   mode?: "compact" | "full"
+  compactBoxSize?: { width: number; height: number }
 }
 
 export default EnergyAC

--- a/src/app/Marine2/components/boxes/EnergyAlternator/EnergyAlternator.tsx
+++ b/src/app/Marine2/components/boxes/EnergyAlternator/EnergyAlternator.tsx
@@ -37,6 +37,7 @@ interface Props {
   alternator: number
   showInstance: boolean
   mode?: "compact" | "full"
+  compactBoxSize?: { width: number; height: number }
 }
 
 export default EnergyAlternator

--- a/src/app/Marine2/components/boxes/EnergyDC/EnergyDC.tsx
+++ b/src/app/Marine2/components/boxes/EnergyDC/EnergyDC.tsx
@@ -16,6 +16,11 @@ const styles: StylesType = {
     mainValue: "text-3xl",
     subValue: "text-lg",
   },
+  // smaller than "sm-s"
+  default: {
+    mainValue: "text-xl",
+    subValue: "text-sm",
+  },
 }
 
 const compactStyles: StylesType = {

--- a/src/app/Marine2/components/boxes/EnergyDC/EnergyDC.tsx
+++ b/src/app/Marine2/components/boxes/EnergyDC/EnergyDC.tsx
@@ -1,12 +1,28 @@
-import React from "react"
+import { useState } from "react"
 import Box from "../../../components/ui/Box"
 import { DcLoadsState } from "@elninotech/mfd-modules"
 import DCIcon from "../../../images/icons/dc.svg"
 import { formatPower, formatValue } from "../../../utils/formatters"
 import { translate } from "react-i18nify"
+import { applyStyles, StylesType } from "app/Marine2/utils/media"
+import classNames from "classnames"
+
+const styles: StylesType = {
+  "sm-s": {
+    mainValue: "text-2xl",
+    subValue: "text-base",
+  },
+  "md-s": {
+    mainValue: "text-3xl",
+    subValue: "text-lg",
+  },
+}
 
 const EnergyDC = ({ mode = "compact", dcLoads }: Props) => {
   const { power, voltage } = dcLoads
+
+  const [boxSize, setBoxSize] = useState<{ width: number; height: number }>({ width: 0, height: 0 })
+  const activeStyles: StylesType = applyStyles(boxSize, styles)
 
   if (isNaN(power) || isNaN(voltage)) {
     return <></>
@@ -35,16 +51,19 @@ const EnergyDC = ({ mode = "compact", dcLoads }: Props) => {
       /* todo: fix types for svg */
       /* @ts-ignore */
       icon={<DCIcon className={"w-5 text-black dark:text-white"} />}
+      getBoxSizeCallback={setBoxSize}
     >
       <div className="w-full h-full flex flex-col">
-        <div className="text-victron-gray dark:text-white text-2xl md-m:text-3xl lg-l:text-4xl">
+        <div className={classNames("text-victron-gray dark:text-white", activeStyles?.mainValue)}>
           {formatValue(power / voltage)}
           <span className="p-0.5 text-victron-gray dark:text-victron-gray-dark">A</span>
         </div>
         <div className="w-full h-full flex content-end flex-wrap">
           <div className="w-full">
             <hr className="w-full h-1 border-victron-gray" />
-            <div className="text-left text-base md-m:text-lg lg-l:text-xl text-victron-gray dark:text-victron-gray-dark">
+            <div
+              className={classNames("text-left text-victron-gray dark:text-victron-gray-dark", activeStyles?.subValue)}
+            >
               {formatPower(power)}
               <span className="p-0.5 text-victron-gray">W</span>
             </div>

--- a/src/app/Marine2/components/boxes/EnergyDC/EnergyDC.tsx
+++ b/src/app/Marine2/components/boxes/EnergyDC/EnergyDC.tsx
@@ -18,26 +18,42 @@ const styles: StylesType = {
   },
 }
 
-const EnergyDC = ({ mode = "compact", dcLoads }: Props) => {
+const compactStyles: StylesType = {
+  "sm-s": {
+    name: "text-sm",
+    value: "text-base",
+    namePadding: "pl-2",
+  },
+  "md-s": {
+    name: "text-base",
+    value: "text-lg",
+    namePadding: "pl-3",
+  },
+}
+
+const EnergyDC = ({ mode = "compact", dcLoads, compactBoxSize }: Props) => {
   const { power, voltage } = dcLoads
 
   const [boxSize, setBoxSize] = useState<{ width: number; height: number }>({ width: 0, height: 0 })
   const activeStyles: StylesType = applyStyles(boxSize, styles)
-
+  let compactActiveStyles: StylesType = {}
+  if (compactBoxSize) {
+    compactActiveStyles = applyStyles(compactBoxSize, compactStyles)
+  }
   if (isNaN(power) || isNaN(voltage)) {
     return <></>
   }
 
   if (mode === "compact") {
     return (
-      <div className="flex flex-row justify-between items-center text-sm md-m:text-base lg-l:text-lg">
-        <div className="flex">
+      <div className={classNames("flex flex-row justify-between items-center", compactActiveStyles?.name)}>
+        <div className="flex items-center">
           {/* todo: fix types for svg */}
           {/* @ts-ignore */}
           <DCIcon className={"w-7 text-black dark:text-white"} />
-          <p className="pl-2 md:pl-3">{translate("boxes.dcLoads")}</p>
+          <p className={classNames(compactActiveStyles?.namePadding)}>{translate("boxes.dcLoads")}</p>
         </div>
-        <p>
+        <p className={classNames(compactActiveStyles?.value)}>
           {formatValue(power / voltage)}
           <span className="p-0.5 text-victron-gray dark:text-victron-gray-dark">A</span>
         </p>
@@ -77,6 +93,7 @@ const EnergyDC = ({ mode = "compact", dcLoads }: Props) => {
 interface Props {
   dcLoads: DcLoadsState
   mode?: "compact" | "full"
+  compactBoxSize?: { width: number; height: number }
 }
 
 export default EnergyDC

--- a/src/app/Marine2/components/boxes/EnergyOverview/EnergyOverview.tsx
+++ b/src/app/Marine2/components/boxes/EnergyOverview/EnergyOverview.tsx
@@ -37,8 +37,18 @@ const EnergyOverview = ({ mode = "compact" }: Props) => {
   const pvCharger = usePvCharger()
   const { alternators } = useAlternators()
   const { windGenerators } = useWindGenerators()
+  const [compactBoxSize, setCompactBoxSize] = React.useState<{ width: number; height: number }>({ width: 0, height: 0 })
 
-  const boxes = getAvailableEnergyBoxes(mode, shoreInputId, acLoads, pvCharger, dcLoads, alternators, windGenerators)
+  const boxes = getAvailableEnergyBoxes(
+    mode,
+    shoreInputId,
+    acLoads,
+    pvCharger,
+    dcLoads,
+    alternators,
+    windGenerators,
+    compactBoxSize
+  )
 
   // TODO: it seems that visibility logic can be improved since the energy component always has an overview box
   useVisibilityNotifier({ widgetName: BoxTypes.ENERGY, visible: boxes.length > 0 })
@@ -55,6 +65,7 @@ const EnergyOverview = ({ mode = "compact" }: Props) => {
         /* @ts-ignore */
         icon={<EnergyIcon className={"w-6 text-victron-gray dark:text-victron-gray-dark"} />}
         linkedView={AppViews.BOX_ENERGY_OVERVIEW}
+        getBoxSizeCallback={setCompactBoxSize}
       >
         <div className="flex flex-col">{boxes}</div>
       </Box>
@@ -71,16 +82,17 @@ const getAvailableEnergyBoxes = function (
   pvCharger: PvChargerState,
   dcLoads: DcLoadsState,
   alternators: AlternatorId[],
-  windGenerators: WindGeneratorId[]
+  windGenerators: WindGeneratorId[],
+  compactBoxSize: { width: number; height: number }
 ) {
   const boxes = []
 
   if (shoreInputId) {
-    boxes.push(<EnergyShore mode={mode} inputId={shoreInputId} />)
+    boxes.push(<EnergyShore mode={mode} inputId={shoreInputId} compactBoxSize={compactBoxSize} />)
   }
 
   if ((pvCharger.current || pvCharger.current === 0) && (pvCharger.power || pvCharger.power === 0)) {
-    boxes.push(<EnergySolar mode={mode} pvCharger={pvCharger} />)
+    boxes.push(<EnergySolar mode={mode} pvCharger={pvCharger} compactBoxSize={compactBoxSize} />)
   }
 
   // Add a divider if there are any AC loads or DC loads in the compact mode
@@ -96,10 +108,10 @@ const getAvailableEnergyBoxes = function (
     )
   }
 
-  if (acLoads.phases) boxes.push(<EnergyAC mode={mode} acLoads={acLoads} />)
+  if (acLoads.phases) boxes.push(<EnergyAC mode={mode} acLoads={acLoads} compactBoxSize={compactBoxSize} />)
 
   if ((dcLoads.current || dcLoads.current === 0) && (dcLoads.voltage || dcLoads.voltage === 0)) {
-    boxes.push(<EnergyDC mode={mode} dcLoads={dcLoads} />)
+    boxes.push(<EnergyDC mode={mode} dcLoads={dcLoads} compactBoxSize={compactBoxSize} />)
   }
 
   const alternatorsPresent = alternators.filter((v) => v || v === 0)
@@ -111,6 +123,7 @@ const getAvailableEnergyBoxes = function (
           mode={mode}
           alternator={alternator ?? 0}
           showInstance={alternators.length > 1}
+          compactBoxSize={compactBoxSize}
         />
       ))
     )
@@ -125,6 +138,7 @@ const getAvailableEnergyBoxes = function (
           mode={mode}
           windGenerator={windGenerator ?? 0}
           showInstance={alternators.length > 1}
+          compactBoxSize={compactBoxSize}
         />
       ))
     )

--- a/src/app/Marine2/components/boxes/EnergyShore/EnergyShore.tsx
+++ b/src/app/Marine2/components/boxes/EnergyShore/EnergyShore.tsx
@@ -17,6 +17,11 @@ const styles: StylesType = {
     mainValue: "text-3xl",
     subValue: "text-lg",
   },
+  // smaller than "sm-s"
+  default: {
+    mainValue: "text-xl",
+    subValue: "text-sm",
+  },
 }
 
 const compactStyles: StylesType = {

--- a/src/app/Marine2/components/boxes/EnergyShore/EnergyShore.tsx
+++ b/src/app/Marine2/components/boxes/EnergyShore/EnergyShore.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from "react"
+import React, { useState } from "react"
 import { useActiveInValues, useActiveSource } from "@elninotech/mfd-modules"
 import { observer } from "mobx-react-lite"
 import Box from "../../../components/ui/Box"

--- a/src/app/Marine2/components/boxes/EnergyShore/EnergyShore.tsx
+++ b/src/app/Marine2/components/boxes/EnergyShore/EnergyShore.tsx
@@ -19,7 +19,22 @@ const styles: StylesType = {
   },
 }
 
-const EnergyShore = ({ mode = "compact", inputId }: Props) => {
+const compactStyles: StylesType = {
+  "sm-s": {
+    name: "text-sm",
+    namePadding: "pl-2",
+    description: "text-xs",
+    value: "text-base",
+  },
+  "md-s": {
+    name: "text-base",
+    namePadding: "pl-3",
+    description: "text-sm",
+    value: "text-lg",
+  },
+}
+
+const EnergyShore = ({ mode = "compact", inputId, compactBoxSize }: Props) => {
   const { current, power } = useActiveInValues()
   const { activeInput, phases } = useActiveSource()
   const unplugged = activeInput + 1 !== inputId // Active in = 0 -> AC1 is active
@@ -27,20 +42,28 @@ const EnergyShore = ({ mode = "compact", inputId }: Props) => {
 
   const [boxSize, setBoxSize] = useState<{ width: number; height: number }>({ width: 0, height: 0 })
   const activeStyles: StylesType = applyStyles(boxSize, styles)
-
+  let compactActiveStyles: StylesType = {}
+  if (compactBoxSize) {
+    compactActiveStyles = applyStyles(compactBoxSize, compactStyles)
+  }
   if (mode === "compact") {
     return (
-      <div className="flex items-center justify-between text-sm md-m:text-base lg-l:text-lg">
-        <div className="flex">
+      <div className={classNames("flex items-center justify-between", compactActiveStyles?.name)}>
+        <div className="flex items-center">
           <ShorePowerIcon
             /* todo: fix types for svg */
             /* @ts-ignore */
             className={"w-7 text-black dark:text-white"}
           />
-          <div className="flex flex-col pl-2 md:pl-3">
+          <div className={classNames("flex flex-col", compactActiveStyles?.namePadding)}>
             <p>{translate("boxes.shorePower")}</p>
             {unplugged && (
-              <small className={"text-sm text-victron-gray dark:text-victron-gray-dark"}>
+              <small
+                className={classNames(
+                  "text-victron-gray dark:text-victron-gray-dark",
+                  compactActiveStyles?.description
+                )}
+              >
                 {translate("common.unplugged")}
               </small>
             )}
@@ -48,19 +71,19 @@ const EnergyShore = ({ mode = "compact", inputId }: Props) => {
         </div>
         {!unplugged ? (
           (phases ?? 1) === 1 ? (
-            <p>
+            <p className={classNames(compactActiveStyles?.value)}>
               {formatValue(current[0])}
               <span className="p-0.5 text-victron-gray dark:text-victron-gray-dark">A</span>
             </p>
           ) : (
-            <p>
+            <p className={classNames(compactActiveStyles?.value)}>
               {formatPower(totalPower)}
               <span className="p-0.5 text-victron-gray dark:text-victron-gray-dark">W</span>
             </p>
           )
         ) : (
-          <div>
-            <p className="hidden text-sm md:block">{translate("common.unplugged")}</p>
+          <div className={classNames(compactActiveStyles?.value)}>
+            <p className="hidden md:block">{translate("common.unplugged")}</p>
             <p className="md:hidden">
               --<span className="p-0.5 text-victron-gray dark:text-victron-gray-dark">A</span>
             </p>
@@ -116,6 +139,7 @@ const EnergyShore = ({ mode = "compact", inputId }: Props) => {
 interface Props {
   inputId: number
   mode?: "compact" | "full"
+  compactBoxSize?: { width: number; height: number }
 }
 
 export default observer(EnergyShore)

--- a/src/app/Marine2/components/boxes/EnergyShore/EnergyShore.tsx
+++ b/src/app/Marine2/components/boxes/EnergyShore/EnergyShore.tsx
@@ -1,16 +1,32 @@
-import React from "react"
+import React, { useEffect, useState } from "react"
 import { useActiveInValues, useActiveSource } from "@elninotech/mfd-modules"
 import { observer } from "mobx-react-lite"
 import Box from "../../../components/ui/Box"
 import ShorePowerIcon from "../../../images/icons/shore-power.svg"
 import { formatValue, formatPower } from "../../../utils/formatters"
 import { translate } from "react-i18nify"
+import { applyStyles, StylesType } from "app/Marine2/utils/media"
+import classNames from "classnames"
+
+const styles: StylesType = {
+  "sm-s": {
+    mainValue: "text-2xl",
+    subValue: "text-base",
+  },
+  "md-s": {
+    mainValue: "text-3xl",
+    subValue: "text-lg",
+  },
+}
 
 const EnergyShore = ({ mode = "compact", inputId }: Props) => {
   const { current, power } = useActiveInValues()
   const { activeInput, phases } = useActiveSource()
   const unplugged = activeInput + 1 !== inputId // Active in = 0 -> AC1 is active
   const totalPower = power.reduce((total, power) => (power ? total + power : total))
+
+  const [boxSize, setBoxSize] = useState<{ width: number; height: number }>({ width: 0, height: 0 })
+  const activeStyles: StylesType = applyStyles(boxSize, styles)
 
   if (mode === "compact") {
     return (
@@ -60,9 +76,14 @@ const EnergyShore = ({ mode = "compact", inputId }: Props) => {
       /* todo: fix types for svg */
       /* @ts-ignore */
       icon={<ShorePowerIcon className={"w-5 text-black dark:text-white"} />}
+      getBoxSizeCallback={setBoxSize}
     >
-      <div className="w-full h-full flex flex-col text-2xl md-m:text-3xl lg-l:text-4xl">
-        {unplugged && <p className="text-victron-gray dark:text-white">{translate("common.unplugged")}</p>}
+      <div className={classNames("w-full h-full flex flex-col", activeStyles?.mainValue)}>
+        {unplugged && (
+          <p>
+            --<span className="p-0.5 text-victron-gray dark:text-victron-gray-dark">A</span>
+          </p>
+        )}
         {!unplugged &&
           ((phases ?? 1) === 1 ? (
             <div className="text-victron-gray dark:text-white">
@@ -79,7 +100,9 @@ const EnergyShore = ({ mode = "compact", inputId }: Props) => {
         <div className="w-full h-full flex content-end flex-wrap">
           <div className="w-full">
             <hr className="w-full h-1 border-victron-gray" />
-            <div className="text-left text-base md-m:text-lg lg-l:text-xl text-victron-gray dark:text-victron-gray-dark">
+            <div
+              className={classNames("text-left text-victron-gray dark:text-victron-gray-dark", activeStyles?.subValue)}
+            >
               {formatPower(totalPower)}
               <span className="p-0.5 text-victron-gray">W</span>
             </div>

--- a/src/app/Marine2/components/boxes/EnergySolar/EnergySolar.tsx
+++ b/src/app/Marine2/components/boxes/EnergySolar/EnergySolar.tsx
@@ -1,12 +1,28 @@
-import React from "react"
+import { useState } from "react"
 import Box from "../../../components/ui/Box"
 import { PvChargerState } from "@elninotech/mfd-modules"
 import SolarIcon from "../../../images/icons/solar.svg"
 import { formatPower, formatValue } from "../../../utils/formatters"
 import { translate } from "react-i18nify"
+import { applyStyles, StylesType } from "app/Marine2/utils/media"
+import classNames from "classnames"
+
+const styles: StylesType = {
+  "sm-s": {
+    mainValue: "text-2xl",
+    subValue: "text-base",
+  },
+  "md-s": {
+    mainValue: "text-3xl",
+    subValue: "text-lg",
+  },
+}
 
 const EnergySolar = ({ mode = "compact", pvCharger }: Props) => {
   const { current, power } = pvCharger
+
+  const [boxSize, setBoxSize] = useState<{ width: number; height: number }>({ width: 0, height: 0 })
+  const activeStyles: StylesType = applyStyles(boxSize, styles)
 
   if (mode === "compact") {
     return (
@@ -31,14 +47,17 @@ const EnergySolar = ({ mode = "compact", pvCharger }: Props) => {
       /* todo: fix types for svg */
       /* @ts-ignore */
       icon={<SolarIcon className={"w-5 text-black dark:text-white"} />}
+      getBoxSizeCallback={(size) => {
+        setBoxSize(size)
+      }}
     >
       <div className="w-full h-full flex flex-col">
-        <div className="text-victron-gray dark:text-white text-2xl md-m:text-3xl lg-l:text-4xl">
+        <div className={classNames("text-victron-gray dark:text-white", activeStyles?.mainValue)}>
           {formatValue(current)}
           <span className="p-0.5 text-victron-gray dark:text-victron-gray-dark">A</span>
         </div>
         <div className="w-full h-full flex content-end flex-wrap">
-          <div className="w-full text-base md-m:text-lg lg-l:text-xl">
+          <div className={classNames("w-full text-base", activeStyles?.subValue)}>
             <hr className="w-full h-1 border-victron-gray" />
             <div className="text-left text-victron-gray dark:text-victron-gray-dark">
               {formatPower(power)}

--- a/src/app/Marine2/components/boxes/EnergySolar/EnergySolar.tsx
+++ b/src/app/Marine2/components/boxes/EnergySolar/EnergySolar.tsx
@@ -18,22 +18,38 @@ const styles: StylesType = {
   },
 }
 
-const EnergySolar = ({ mode = "compact", pvCharger }: Props) => {
+const compactStyles: StylesType = {
+  "sm-s": {
+    name: "text-sm",
+    value: "text-base",
+    namePadding: "pl-2",
+  },
+  "md-s": {
+    name: "text-base",
+    value: "text-lg",
+    namePadding: "pl-3",
+  },
+}
+
+const EnergySolar = ({ mode = "compact", pvCharger, compactBoxSize }: Props) => {
   const { current, power } = pvCharger
 
   const [boxSize, setBoxSize] = useState<{ width: number; height: number }>({ width: 0, height: 0 })
   const activeStyles: StylesType = applyStyles(boxSize, styles)
-
+  let compactActiveStyles: StylesType = {}
+  if (compactBoxSize) {
+    compactActiveStyles = applyStyles(compactBoxSize, compactStyles)
+  }
   if (mode === "compact") {
     return (
-      <div className="flex flex-row justify-between items-center text-sm md-m:text-base lg-l:text-lg">
-        <div className="flex">
+      <div className={classNames("flex flex-row justify-between items-center", compactActiveStyles?.name)}>
+        <div className="flex items-center">
           {/* todo: fix types for svg */}
           {/* @ts-ignore */}
           <SolarIcon className={"w-7 text-black dark:text-white"} />
-          <p className="pl-2 md:pl-3">{translate("boxes.solar")}</p>
+          <p className={classNames(compactActiveStyles?.namePadding)}>{translate("boxes.solar")}</p>
         </div>
-        <p>
+        <p className={classNames(compactActiveStyles?.value)}>
           {formatValue(current)}
           <span className="p-0.5 text-victron-gray dark:text-victron-gray-dark">A</span>
         </p>
@@ -57,7 +73,7 @@ const EnergySolar = ({ mode = "compact", pvCharger }: Props) => {
           <span className="p-0.5 text-victron-gray dark:text-victron-gray-dark">A</span>
         </div>
         <div className="w-full h-full flex content-end flex-wrap">
-          <div className={classNames("w-full text-base", activeStyles?.subValue)}>
+          <div className={classNames("w-full", activeStyles?.subValue)}>
             <hr className="w-full h-1 border-victron-gray" />
             <div className="text-left text-victron-gray dark:text-victron-gray-dark">
               {formatPower(power)}
@@ -73,6 +89,7 @@ const EnergySolar = ({ mode = "compact", pvCharger }: Props) => {
 interface Props {
   pvCharger: PvChargerState
   mode?: "compact" | "full"
+  compactBoxSize?: { width: number; height: number }
 }
 
 export default EnergySolar

--- a/src/app/Marine2/components/boxes/EnergySolar/EnergySolar.tsx
+++ b/src/app/Marine2/components/boxes/EnergySolar/EnergySolar.tsx
@@ -16,6 +16,11 @@ const styles: StylesType = {
     mainValue: "text-3xl",
     subValue: "text-lg",
   },
+  // smaller than "sm-s"
+  default: {
+    mainValue: "text-xl",
+    subValue: "text-sm",
+  },
 }
 
 const compactStyles: StylesType = {

--- a/src/app/Marine2/components/boxes/EnergyWind/EnergyWind.tsx
+++ b/src/app/Marine2/components/boxes/EnergyWind/EnergyWind.tsx
@@ -38,6 +38,7 @@ interface Props {
   windGenerator: number
   showInstance: boolean
   mode?: "compact" | "full"
+  compactBoxSize?: { width: number; height: number }
 }
 
 export default observer(EnergyWind)

--- a/src/app/Marine2/components/boxes/Tanks/Tank.tsx
+++ b/src/app/Marine2/components/boxes/Tanks/Tank.tsx
@@ -8,10 +8,27 @@ import FuelIcon from "../../../images/icons/fuel.svg"
 import WaterIcon from "../../../images/icons/fresh-water.svg"
 import BlackWaterIcon from "../../../images/icons/black-water.svg"
 import GrayWaterIcon from "../../../images/icons/waste-water.svg"
+import { applyStyles, StylesType } from "app/Marine2/utils/media"
 
-const Tank = ({ tankInstanceId, mode, orientation = "vertical" }: Props) => {
+const styles: StylesType = {
+  "sm-s": {
+    tankName: "text-sm",
+    level: "text-base",
+  },
+  "md-s": {
+    tankName: "text-base",
+    level: "text-lg",
+  },
+}
+
+const Tank = ({ tankInstanceId, mode, orientation = "vertical", parentSize }: Props) => {
   let { capacity, fluidType, level, remaining, unit } = useTank(tankInstanceId)
   const fluidTypeNum = +fluidType
+
+  let activeStyles: StylesType = {}
+  if (parentSize) {
+    activeStyles = applyStyles(parentSize, styles)
+  }
 
   const fluidTypeTitle = useMemo(() => {
     const fluids = [
@@ -50,7 +67,7 @@ const Tank = ({ tankInstanceId, mode, orientation = "vertical" }: Props) => {
           <div className="col-span-6 flex items-center sm:col-span-4 lg:col-span-3">
             <div>{fluidIcon(fluidTypeNum, mode)}</div>
             <div className="flex flex-col p-1 sm:p-2 w-full">
-              <div className="text-sm md-m:text-base lg-l:text-lg truncate text-ellipsis overflow-hidden">
+              <div className={classnames("truncate text-ellipsis overflow-hidden", activeStyles?.tankName)}>
                 {fluidTypeTitle}
               </div>
             </div>
@@ -60,7 +77,7 @@ const Tank = ({ tankInstanceId, mode, orientation = "vertical" }: Props) => {
           </div>
           <div className="col-span-1 flex items-center justify-center">
             <div
-              className={classnames("text-base md-m:text-lg lg-l:text-xl flex flex-row pr-2", {
+              className={classnames("flex flex-row pr-2", activeStyles?.level, {
                 "text-victron-red": level > 75,
               })}
             >
@@ -201,6 +218,7 @@ interface Props {
   tankInstanceId: number
   mode?: "compact" | "full"
   orientation?: "vertical" | "horizontal"
+  parentSize?: { width: number; height: number }
 }
 
 export default observer(Tank)

--- a/src/app/Marine2/components/boxes/Tanks/Tanks.tsx
+++ b/src/app/Marine2/components/boxes/Tanks/Tanks.tsx
@@ -18,7 +18,12 @@ interface Props {
 
 const Tanks = ({ mode, className }: Props) => {
   const { tanks } = useTanks()
+  const [boxSize, setBoxSize] = useState<{ width: number; height: number }>()
 
+  useEffect(() => {
+    if (!boxSize) return
+    console.log("boxSize", boxSize)
+  }, [boxSize])
   useVisibilityNotifier({ widgetName: BoxTypes.TANKS, visible: !!(tanks && tanks.length) })
 
   const gridRef = useRef<HTMLDivElement>(null)
@@ -48,10 +53,13 @@ const Tanks = ({ mode, className }: Props) => {
         icon={<TanksIcon className={"w-6 text-black dark:text-white"} />}
         linkedView={AppViews.BOX_TANKS}
         className={className}
+        getBoxSizeCallback={(size) => {
+          setBoxSize(size)
+        }}
       >
         <div>
           {tanks?.map((tank) => {
-            return tank ? <Tank mode={"compact"} key={tank} tankInstanceId={tank} /> : null
+            return tank ? <Tank mode={"compact"} key={tank} tankInstanceId={tank} parentSize={boxSize} /> : null
           })}
         </div>
       </Box>

--- a/src/app/Marine2/components/boxes/Tanks/Tanks.tsx
+++ b/src/app/Marine2/components/boxes/Tanks/Tanks.tsx
@@ -20,6 +20,10 @@ const Tanks = ({ mode, className }: Props) => {
   const { tanks } = useTanks()
   const [boxSize, setBoxSize] = useState<{ width: number; height: number }>({ width: 0, height: 0 })
 
+  useEffect(() => {
+    if (!boxSize) return
+    console.log("boxSize", boxSize)
+  }, [boxSize])
   useVisibilityNotifier({ widgetName: BoxTypes.TANKS, visible: !!(tanks && tanks.length) })
 
   const gridRef = useRef<HTMLDivElement>(null)

--- a/src/app/Marine2/components/boxes/Tanks/Tanks.tsx
+++ b/src/app/Marine2/components/boxes/Tanks/Tanks.tsx
@@ -18,12 +18,8 @@ interface Props {
 
 const Tanks = ({ mode, className }: Props) => {
   const { tanks } = useTanks()
-  const [boxSize, setBoxSize] = useState<{ width: number; height: number }>()
+  const [boxSize, setBoxSize] = useState<{ width: number; height: number }>({ width: 0, height: 0 })
 
-  useEffect(() => {
-    if (!boxSize) return
-    console.log("boxSize", boxSize)
-  }, [boxSize])
   useVisibilityNotifier({ widgetName: BoxTypes.TANKS, visible: !!(tanks && tanks.length) })
 
   const gridRef = useRef<HTMLDivElement>(null)
@@ -53,9 +49,7 @@ const Tanks = ({ mode, className }: Props) => {
         icon={<TanksIcon className={"w-6 text-black dark:text-white"} />}
         linkedView={AppViews.BOX_TANKS}
         className={className}
-        getBoxSizeCallback={(size) => {
-          setBoxSize(size)
-        }}
+        getBoxSizeCallback={setBoxSize}
       >
         <div>
           {tanks?.map((tank) => {

--- a/src/app/Marine2/components/boxes/Tanks/Tanks.tsx
+++ b/src/app/Marine2/components/boxes/Tanks/Tanks.tsx
@@ -20,10 +20,6 @@ const Tanks = ({ mode, className }: Props) => {
   const { tanks } = useTanks()
   const [boxSize, setBoxSize] = useState<{ width: number; height: number }>({ width: 0, height: 0 })
 
-  useEffect(() => {
-    if (!boxSize) return
-    console.log("boxSize", boxSize)
-  }, [boxSize])
   useVisibilityNotifier({ widgetName: BoxTypes.TANKS, visible: !!(tanks && tanks.length) })
 
   const gridRef = useRef<HTMLDivElement>(null)

--- a/src/app/Marine2/components/ui/Box/Box.tsx
+++ b/src/app/Marine2/components/ui/Box/Box.tsx
@@ -1,18 +1,28 @@
-import React from "react"
+import React, { useEffect } from "react"
 import classNames from "classnames"
 import ArrowRightIcon from "../../../images/icons/arrow-right.svg"
 import { AppViews, useAppViewsStore } from "../../../modules/AppViews"
+import { useComponentSize } from "app/Marine2/utils/hooks"
 
-const Box = ({ children, icon, title, className, linkedView }: BoxProps) => {
+const Box = ({ children, icon, title, className, linkedView, getBoxSizeCallback }: BoxProps) => {
   const appViewsStore = useAppViewsStore()
   const handleClick = () => {
     if (linkedView) {
       appViewsStore.setView(linkedView)
     }
   }
+  const boxRef = React.useRef<HTMLDivElement>(null)
+  const componentSize = useComponentSize(boxRef)
+
+  useEffect(() => {
+    if (getBoxSizeCallback) {
+      getBoxSizeCallback(componentSize)
+    }
+  }, [componentSize])
 
   return (
     <div
+      ref={boxRef}
       className={classNames(
         "w-full h-full min-h-0 p-4 flex flex-col bg-victron-lightGray dark:bg-victron-darkGray rounded-md",
         className
@@ -51,6 +61,7 @@ export interface BoxProps {
   linkedView?: AppViews
   className?: string
   headerActions?: JSX.Element
+  getBoxSizeCallback?: (size: { width: number; height: number }) => void
 }
 
 export default Box

--- a/src/app/Marine2/components/ui/Box/Box.tsx
+++ b/src/app/Marine2/components/ui/Box/Box.tsx
@@ -18,7 +18,7 @@ const Box = ({ children, icon, title, className, linkedView, getBoxSizeCallback 
     if (getBoxSizeCallback) {
       getBoxSizeCallback(componentSize)
     }
-  }, [componentSize])
+  }, [componentSize, getBoxSizeCallback])
 
   return (
     <div

--- a/src/app/Marine2/utils/media.tsx
+++ b/src/app/Marine2/utils/media.tsx
@@ -35,5 +35,10 @@ export const applyStyles = (size: ComponentSizeType, stylesObject: StylesType) =
       styles = { ...styles, ...stylesObject[breakpoint] }
     }
   })
+
+  if (Object.keys(styles).length === 0) {
+    styles = stylesObject["default"]
+  }
+
   return styles
 }

--- a/src/app/Marine2/utils/media.tsx
+++ b/src/app/Marine2/utils/media.tsx
@@ -1,0 +1,39 @@
+export type StylesType = {
+  [key: string]: {
+    [key: string]: string
+  }
+}
+
+type ComponentSizeType = {
+  width: number
+  height: number
+}
+
+type BreakpointsType = {
+  [key: string]: ComponentSizeType
+}
+
+const boxBreakpoints: BreakpointsType = {
+  "sm-s": { width: 200, height: 200 },
+  "sm-m": { width: 200, height: 450 },
+  "sm-l": { width: 200, height: 600 },
+  "md-s": { width: 400, height: 200 },
+  "md-m": { width: 400, height: 450 },
+  "md-l": { width: 400, height: 600 },
+  "lg-s": { width: 600, height: 200 },
+  "lg-m": { width: 600, height: 450 },
+  "lg-l": { width: 600, height: 600 },
+}
+
+export const applyStyles = (size: ComponentSizeType, stylesObject: StylesType) => {
+  let styles = {}
+
+  Object.keys(boxBreakpoints).forEach((breakpoint) => {
+    const breakpointWidth = boxBreakpoints[breakpoint].width
+    const breakpointHeight = boxBreakpoints[breakpoint].height
+    if (size.width >= breakpointWidth && size.height >= breakpointHeight) {
+      styles = { ...styles, ...stylesObject[breakpoint] }
+    }
+  })
+  return styles
+}


### PR DESCRIPTION
In this PR:

- Add component size-based media breakpoints
- Apply font size styles based on the box size
- Breakpoints are defined for now in `media.ts` as `boxBreakpoints` and might need to change