### PR TITLE
Add automatic perPage recalculation for GridPaginator

### DIFF
--- a/src/app/Marine2/components/boxes/BatteriesOverview/BatteriesOverview.tsx
+++ b/src/app/Marine2/components/boxes/BatteriesOverview/BatteriesOverview.tsx
@@ -53,7 +53,7 @@ const BatteriesOverview = ({ mode = "full", pageSelectorPropsSetter }: Props) =>
   return (
     <GridPaginator
       childClassName={"p-2"}
-      childrenPerPage={4}
+      perPage={4}
       orientation={"horizontal"}
       pageSelectorPropsSetter={pageSelectorPropsSetter}
       flow={window.innerWidth > window.innerHeight ? "row" : "col"}

--- a/src/app/Marine2/components/boxes/EnergyOverview/EnergyOverview.tsx
+++ b/src/app/Marine2/components/boxes/EnergyOverview/EnergyOverview.tsx
@@ -80,7 +80,7 @@ const EnergyOverview = ({ mode = "full", pageSelectorPropsSetter }: Props) => {
   return (
     <GridPaginator
       childClassName={"p-2"}
-      childrenPerPage={4}
+      perPage={4}
       orientation={"horizontal"}
       pageSelectorPropsSetter={pageSelectorPropsSetter}
     >

--- a/src/app/Marine2/components/ui/GridPaginator/GridPaginator.test.js
+++ b/src/app/Marine2/components/ui/GridPaginator/GridPaginator.test.js
@@ -6,7 +6,7 @@ import GridPaginator from "./GridPaginator"
 describe("GridPaginator element", () => {
   describe("renders content", () => {
     const wrapper = mount(
-      <GridPaginator childrenPerPage={4}>
+      <GridPaginator perPage={4}>
         <Box title={"Box1"}>Box1</Box>
         <Box title={"Box2"}>Box2</Box>
         <Box title={"Box3"}>Box3</Box>
@@ -22,7 +22,7 @@ describe("GridPaginator element", () => {
   describe("without paginator", () => {
     it("should not show paginator if children count is less than defined", () => {
       const wrapper = mount(
-        <GridPaginator childrenPerPage={4}>
+        <GridPaginator perPage={4}>
           <Box title={"Box1"}>Box1</Box>
           <Box title={"Box2"}>Box2</Box>
         </GridPaginator>
@@ -33,7 +33,7 @@ describe("GridPaginator element", () => {
 
     it("should not show paginator if children count is equal to defined", () => {
       const wrapper = mount(
-        <GridPaginator childrenPerPage={4}>
+        <GridPaginator perPage={4}>
           <Box title={"Box1"}>Box1</Box>
           <Box title={"Box2"}>Box2</Box>
           <Box title={"Box3"}>Box3</Box>
@@ -47,7 +47,7 @@ describe("GridPaginator element", () => {
 
   describe("with paginator", () => {
     const wrapper = mount(
-      <GridPaginator childrenPerPage={2}>
+      <GridPaginator perPage={2}>
         <Box title={"Box1"}>Box1</Box>
         <Box title={"Box2"}>Box2</Box>
         <Box title={"Box3"}>Box3</Box>

--- a/src/app/Marine2/components/ui/GridPaginator/GridPaginator.tsx
+++ b/src/app/Marine2/components/ui/GridPaginator/GridPaginator.tsx
@@ -1,9 +1,11 @@
-import React from "react"
+import React, { useEffect, useRef, useState } from "react"
 import Grid, { GridProps } from "../Grid"
 import range from "lodash-es/range"
 import classnames from "classnames"
 import PageFlipper from "../PageFlipper"
 import { PageSelectorProps } from "../PageSelector"
+import { useComponentSize } from "../../../utils/hooks"
+import { boxBreakpoints } from "../../../utils/media"
 
 const GridPaginator = ({
   children,
@@ -16,18 +18,57 @@ const GridPaginator = ({
   orientation = "horizontal",
   pageSelectorPropsSetter,
 }: Props) => {
+  const [childrenPerPage, setChildrenPerPage] = useState(perPage)
+
+  const gridPaginatorRef = useRef<HTMLDivElement>(null)
+  const gridPaginatorSize = useComponentSize(gridPaginatorRef)
+
   const childrenArray = Array.isArray(children) ? children : [children]
   const pages = Math.ceil(childrenArray.length / childrenPerPage)
 
+  // automatically change perPage if grid size is too small
+  useEffect(() => {
+    if (!gridPaginatorSize.width || !gridPaginatorSize.height) {
+      return
+    }
+
+    let forcePerPage = perPage
+
+    if (gridPaginatorSize.width < boxBreakpoints["lg-s"].width) {
+      forcePerPage = 2
+    }
+
+    if (gridPaginatorSize.width < boxBreakpoints["md-s"].width) {
+      forcePerPage = 1
+    }
+
+    if (forcePerPage !== childrenPerPage) {
+      setChildrenPerPage(forcePerPage)
+    }
+
+    // We need to reset pagination if there is only one page
+    // TODO: remake this to use store states instead of props down the tree
+    if (Math.ceil(childrenArray.length / forcePerPage) === 1) {
+      pageSelectorPropsSetter &&
+        pageSelectorPropsSetter({
+          currentPage: 0,
+          maxPages: 0,
+        })
+    }
+  }, [gridPaginatorSize, childrenPerPage, perPage, childrenArray.length, pageSelectorPropsSetter])
+
   if (pages === 1) {
     return (
-      <Grid childClassName={childClassName} flow={flow} className={className}>
-        {childrenArray}
-      </Grid>
+      <div className={"h-full w-full min-h-0 min-w-0"} ref={gridPaginatorRef}>
+        <Grid childClassName={childClassName} flow={flow} className={className}>
+          {childrenArray}
+        </Grid>
+      </div>
     )
   }
+
   return (
-    <div className={"h-full w-full min-h-0 min-w-0"}>
+    <div className={"h-full w-full min-h-0 min-w-0"} ref={gridPaginatorRef}>
       <PageFlipper pages={pages} pageSelectorPropsSetter={pageSelectorPropsSetter}>
         <div
           className={classnames(`flex`, {

--- a/src/app/Marine2/components/ui/GridPaginator/GridPaginator.tsx
+++ b/src/app/Marine2/components/ui/GridPaginator/GridPaginator.tsx
@@ -12,7 +12,7 @@ const GridPaginator = ({
   flow,
   forceOneDimensionRatio,
   onClick,
-  childrenPerPage,
+  perPage,
   orientation = "horizontal",
   pageSelectorPropsSetter,
 }: Props) => {
@@ -59,7 +59,7 @@ const GridPaginator = ({
 }
 
 interface Props extends GridProps {
-  childrenPerPage: number
+  perPage: number
   orientation?: "vertical" | "horizontal"
   pageSelectorPropsSetter?: (arg0: PageSelectorProps) => void
 }

--- a/src/app/Marine2/components/ui/PageSelector/PageSelector.tsx
+++ b/src/app/Marine2/components/ui/PageSelector/PageSelector.tsx
@@ -154,6 +154,7 @@ const PageSelector = ({
   )
 }
 
+// TODO: remake this to use store states instead of props down the tree
 export interface PageSelectorProps {
   currentPage?: number
   maxPages?: number

--- a/src/app/Marine2/components/views/RootView.tsx
+++ b/src/app/Marine2/components/views/RootView.tsx
@@ -54,7 +54,7 @@ const RootView = () => {
       <div className="hidden">{initialBoxes.map((box) => box)}</div>
       <MainLayout pageSelectorProps={pageSelectorProps}>
         <GridPaginator
-          childrenPerPage={4}
+          perPage={4}
           flow={"col"}
           orientation={"horizontal"}
           childClassName={"p-2"}

--- a/src/app/Marine2/components/views/RootView.tsx
+++ b/src/app/Marine2/components/views/RootView.tsx
@@ -52,6 +52,7 @@ const RootView = () => {
     <>
       {/* We need to have hidden boxes mounted to listen to mqtt data and manage boxes visibility */}
       <div className="hidden">{initialBoxes.map((box) => box)}</div>
+      {/* TODO: remake this to use store states instead of pageSelectorProps down the tree */}
       <MainLayout pageSelectorProps={pageSelectorProps}>
         <GridPaginator
           perPage={4}

--- a/src/app/Marine2/utils/media.tsx
+++ b/src/app/Marine2/utils/media.tsx
@@ -15,7 +15,7 @@ type BreakpointsType = {
   [key: string]: ComponentSizeType
 }
 
-const boxBreakpoints: BreakpointsType = {
+export const boxBreakpoints: BreakpointsType = {
   "sm-s": { width: 200, height: 300 },
   "sm-m": { width: 200, height: 450 },
   "sm-l": { width: 200, height: 600 },


### PR DESCRIPTION
## Changes

For small widths and narrow layouts automatically recalculate (reduce) GridPaginator perPage prop to better fit the content.

## Example

Enough space, show 3 blocks:
<img width="774" alt="image" src="https://user-images.githubusercontent.com/5647345/226696150-8e35a31a-bbd9-45b7-8414-3eec0429dd02.png">

Narrow space, show 2 blocks + pagination:
<img width="456" alt="image" src="https://user-images.githubusercontent.com/5647345/226696336-4c17389e-f53e-43bd-9cda-7bae51836e0f.png">

Very narrow space, show 1 block + pagination:
<img width="285" alt="image" src="https://user-images.githubusercontent.com/5647345/226696486-580c7ccd-10e8-4a6d-940e-26273062cddd.png">
