### PR TITLE
remove vrm info from version info

### DIFF
--- a/src/app/Marine2/components/ui/VersionInfo/VersionInfo.tsx
+++ b/src/app/Marine2/components/ui/VersionInfo/VersionInfo.tsx
@@ -1,5 +1,5 @@
 import { observer } from "mobx-react"
-import { useAppStore, useMqtt, useVrmStore } from "@elninotech/mfd-modules"
+import { useAppStore, useMqtt } from "@elninotech/mfd-modules"
 import { Translate, translate } from "react-i18nify"
 import { Modal } from "../Modal"
 import { BUILD_TIMESTAMP } from "../../../utils/constants"

--- a/src/app/Marine2/components/ui/VersionInfo/VersionInfo.tsx
+++ b/src/app/Marine2/components/ui/VersionInfo/VersionInfo.tsx
@@ -20,7 +20,6 @@ const VersionInfo = () => {
   }
 
   const toggleVersionInfo = () => {
-    console.log()
     setIsModalOpen(!isModalOpen)
   }
 

--- a/src/app/Marine2/components/ui/VersionInfo/VersionInfo.tsx
+++ b/src/app/Marine2/components/ui/VersionInfo/VersionInfo.tsx
@@ -1,5 +1,5 @@
 import { observer } from "mobx-react"
-import { useAppStore, useVrmStore } from "@elninotech/mfd-modules"
+import { useAppStore, useMqtt, useVrmStore } from "@elninotech/mfd-modules"
 import { Translate, translate } from "react-i18nify"
 import { Modal } from "../Modal"
 import { BUILD_TIMESTAMP } from "../../../utils/constants"
@@ -11,15 +11,16 @@ import Button from "../Button"
 
 const VersionInfo = () => {
   const [isModalOpen, setIsModalOpen] = useState(false)
-  const { portalId = "-", siteId = "-" } = useVrmStore()
   const { humanReadableFirmwareVersion } = useAppStore()
   const appViewsStore = useAppViewsStore()
+  const { portalId } = useMqtt()
 
   const openDiagnostics = () => {
     appViewsStore.setView(AppViews.DIAGNOSTICS)
   }
 
   const toggleVersionInfo = () => {
+    console.log()
     setIsModalOpen(!isModalOpen)
   }
 
@@ -66,10 +67,6 @@ const VersionInfo = () => {
                     <div className="flex flex-row justify-between">
                       <div>{translate("versionInfo.identifier")}</div>
                       <div>{portalId}</div>
-                    </div>
-                    <div className="flex flex-row justify-between">
-                      <div>{translate("versionInfo.vrmPortID")}</div>
-                      <div>{siteId}</div>
                     </div>
                   </div>
                   <div className={"pt-2"}>


### PR DESCRIPTION
We never log in so these are always empty, replaced with the identifier