### PR TITLE
Use GridPaginator for batteries overview and take into account pagination

### DIFF
--- a/src/app/Marine2/components/boxes/BatteriesOverview/BatteriesOverview.tsx
+++ b/src/app/Marine2/components/boxes/BatteriesOverview/BatteriesOverview.tsx
@@ -37,15 +37,16 @@ const BatteriesOverview = ({ mode = "full", pageSelectorPropsSetter }: Props) =>
         title={translate("boxes.batteries")}
         linkedView={AppViews.BOX_BATTERIES_OVERVIEW}
         getBoxSizeCallback={setBoxSize}
-        withPagination={true}
       >
-        <div className={"flex w-fit min-w-full h-full justify-center"}>
+        {/* TODO: set max items per page based on the available space */}
+        <GridPaginator perPage={2}>
           {overviewBatteries.map((b) => (
             <div key={b.id} className={"h-full flex items-center justify-center"}>
-              <BatterySummary key={b.id} battery={b} boxSize={boxSize} />
+              {/* TODO: Take into account pagination being active for box size instead of this 'trick' */}
+              <BatterySummary key={b.id} battery={b} boxSize={{ width: boxSize.width, height: boxSize.height - 50 }} />
             </div>
           ))}
-        </div>
+        </GridPaginator>
       </Box>
     )
   }


### PR DESCRIPTION
Prevents overlap of paginator and batteries, as well as batteries being cut off. Not a proper fix for this issue in general, just for the release in case we don't have a fix on time. Remaining issues:
- No more than two batteries can be shown on the overview at once, only one or two.
- On small windows, there is no way to fit the smallest battery size in the box together with the paginator. Could not find a design for this case.