### PR TITLE
Error boundary fixes

### DIFF
--- a/.env
+++ b/.env
@@ -4,6 +4,7 @@ BUILD_PATH=./dist
 # Whitelabels:
 # 1. "KVNRV" - Generic RV-themed whitelabel
 # 2. "Marine" - the original theme of the Venus HTML5 App
+# 3. "Marine2" - the new Venus HTML5 App theme 
 REACT_APP_WHITELABEL=Marine
 # Allow overriding the language via the ?lang= URL parameter (disabled in production)
 REACT_APP_ENABLE_LANG_OVERRIDE=true

--- a/src/app/Marine2/App.test.js
+++ b/src/app/Marine2/App.test.js
@@ -1,13 +1,12 @@
-import { mount } from "enzyme"
+import { mount, shallow } from "enzyme"
 import React from "react"
 import App from "./App"
 
 describe("App element", () => {
   describe("error boundary", () => {
-    const wrapper = mount(<App />)
+    const wrapper = shallow(<App />)
 
     it("should use error boundary", () => {
-      console.log("-> wrapper.debug()", wrapper.debug())
       const errorBoundary = wrapper.find("ErrorBoundary")
       expect(errorBoundary.exists()).toBe(true)
       expect(errorBoundary.find("Memo(App)").exists()).toBe(true)

--- a/src/app/Marine2/App.test.js
+++ b/src/app/Marine2/App.test.js
@@ -1,0 +1,20 @@
+import { mount } from "enzyme"
+import React from "react"
+import App from "./App"
+
+describe("App element", () => {
+  describe("error boundary", () => {
+    const wrapper = mount(<App />)
+
+    it("should use error boundary", () => {
+      console.log("-> wrapper.debug()", wrapper.debug())
+      const errorBoundary = wrapper.find("ErrorBoundary")
+      expect(errorBoundary.exists()).toBe(true)
+      expect(errorBoundary.find("Memo(App)").exists()).toBe(true)
+    })
+  })
+
+  describe("todo", () => {
+    it.todo("should show content")
+  })
+})

--- a/src/app/Marine2/components/boxes/BatteriesOverview/BatteriesOverview.test.js
+++ b/src/app/Marine2/components/boxes/BatteriesOverview/BatteriesOverview.test.js
@@ -38,16 +38,6 @@ describe("BatteriesOverview element", () => {
     })
   })
 
-  describe("error boundary", () => {
-    const wrapper = mount(<BatteriesOverview />)
-
-    it("should use error boundary", () => {
-      const errorBoundary = wrapper.find("ErrorBoundary")
-      expect(errorBoundary.exists()).toBe(true)
-      expect(errorBoundary.find("Memo(BatteriesOverview)").exists()).toBe(true)
-    })
-  })
-
   describe("todo", () => {
     it.todo("should show summary")
     it.todo("should show details")

--- a/src/app/Marine2/components/boxes/BatteriesOverview/BatteriesOverview.tsx
+++ b/src/app/Marine2/components/boxes/BatteriesOverview/BatteriesOverview.tsx
@@ -5,10 +5,8 @@ import { BATTERY, BoxTypes } from "../../../utils/constants"
 import Battery from "../Battery/Battery"
 import BatteriesIcon from "../../../images/icons/batteries.svg"
 import BatterySummary from "../../ui/BatterySummary"
-import { withErrorBoundary } from "react-error-boundary"
 import { AppViews } from "../../../modules/AppViews"
 import { translate } from "react-i18nify"
-import { appErrorBoundaryProps } from "../../ui/Error/appErrorBoundary"
 import { useVisibilityNotifier } from "../../../modules"
 import GridPaginator from "../../ui/GridPaginator"
 import { useState } from "react"
@@ -100,4 +98,4 @@ const getOverviewBatteries = function (batteries: BatteryType[]) {
   return batteries.slice(0, withStateCount)
 }
 
-export default withErrorBoundary(observer(BatteriesOverview), appErrorBoundaryProps)
+export default observer(BatteriesOverview)

--- a/src/app/Marine2/components/boxes/EnergyOverview/EnergyOverview.test.js
+++ b/src/app/Marine2/components/boxes/EnergyOverview/EnergyOverview.test.js
@@ -38,15 +38,6 @@ describe("EnergyOverview element", () => {
     })
   })
 
-  describe("error boundary", () => {
-    const wrapper = mount(<EnergyOverview />)
-
-    it("should use error boundary", () => {
-      expect(wrapper.find("ErrorBoundary").exists()).toBe(true)
-      expect(wrapper.find("ErrorBoundary").children().find("Memo(EnergyOverview)").exists()).toBe(true)
-    })
-  })
-
   describe("todo", () => {
     it.todo("should show summary")
     it.todo("should show details")

--- a/src/app/Marine2/components/boxes/EnergyOverview/EnergyOverview.tsx
+++ b/src/app/Marine2/components/boxes/EnergyOverview/EnergyOverview.tsx
@@ -28,8 +28,6 @@ import { useVisibilityNotifier } from "../../../modules"
 import { BoxTypes } from "../../../utils/constants"
 import GridPaginator from "../../ui/GridPaginator"
 import { PageSelectorProps } from "../../ui/PageSelector"
-import { withErrorBoundary } from "react-error-boundary"
-import { appErrorBoundaryProps } from "../../ui/Error/appErrorBoundary"
 
 const EnergyOverview = ({ mode = "full", pageSelectorPropsSetter }: Props) => {
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
@@ -153,4 +151,4 @@ interface Props {
   pageSelectorPropsSetter?: (arg0: PageSelectorProps) => void
 }
 
-export default withErrorBoundary(observer(EnergyOverview), appErrorBoundaryProps)
+export default observer(EnergyOverview)

--- a/src/app/Marine2/components/boxes/Tanks/Tank.tsx
+++ b/src/app/Marine2/components/boxes/Tanks/Tank.tsx
@@ -98,11 +98,11 @@ const Tank = ({ tankInstanceId, mode, levelWidth, orientation = "vertical", pare
       translate("tankWidget.Oil"),
       translate("tankWidget.Black water"),
       translate("tankWidget.Gasoline"),
-      translate("Diesel"),
-      translate("Liquid Petroleum Gas (LPG)"),
-      translate("Liquid Natural Gas (LNG)"),
-      translate("Hydraulic oil"),
-      translate("Raw water"),
+      translate("tankWidget.Diesel"),
+      translate("tankWidget.LPG"),
+      translate("tankWidget.LNG"),
+      translate("tankWidget.Hydraulic oil"),
+      translate("tankWidget.Raw water"),
     ]
 
     return fluids[fluidTypeNum]

--- a/src/app/Marine2/components/boxes/Tanks/Tanks.test.js
+++ b/src/app/Marine2/components/boxes/Tanks/Tanks.test.js
@@ -39,15 +39,6 @@ describe("Tanks element", () => {
     })
   })
 
-  describe("error boundary", () => {
-    const wrapper = mount(<Tanks />)
-
-    it("should use error boundary", () => {
-      expect(wrapper.find("ErrorBoundary").exists()).toBe(true)
-      expect(wrapper.find("ErrorBoundary").children().find("Memo(Tanks)").exists()).toBe(true)
-    })
-  })
-
   describe("todo", () => {
     it.todo("should show summary")
     it.todo("should show details")

--- a/src/app/Marine2/components/boxes/Tanks/Tanks.tsx
+++ b/src/app/Marine2/components/boxes/Tanks/Tanks.tsx
@@ -6,8 +6,6 @@ import { useWindowSize } from "../../../utils/hooks"
 import Box from "../../ui/Box"
 import Tank from "./Tank"
 import { AppViews } from "../../../modules/AppViews"
-import { withErrorBoundary } from "react-error-boundary"
-import { appErrorBoundaryProps } from "../../ui/Error/appErrorBoundary"
 import { useVisibilityNotifier } from "../../../modules"
 import { BoxTypes } from "../../../utils/constants"
 import Paginator from "../../ui/Paginator"
@@ -176,4 +174,4 @@ const Tanks = ({ mode = "full", className }: Props) => {
   }
 }
 
-export default withErrorBoundary(observer(Tanks), appErrorBoundaryProps)
+export default observer(Tanks)

--- a/src/app/Marine2/components/views/DiagnosticsView.tsx
+++ b/src/app/Marine2/components/views/DiagnosticsView.tsx
@@ -46,7 +46,7 @@ const getConnectionDiagnostics = (mqtt: MqttStore) => {
     },
     {
       property: translate("diagnostics.connection.error"),
-      value: mqtt.error ? `${mqtt.error}` : translate("diagnostics.connection.noError"),
+      value: mqtt.error ? `${mqtt.error}` : translate("diagnostics.connection.none"),
     },
     {
       property: translate("diagnostics.connection.host"),

--- a/src/app/locales/languages/de.json
+++ b/src/app/locales/languages/de.json
@@ -100,7 +100,7 @@
             "connection": "Verbindung",
             "error": "Fehler",
             "host": "Host",
-            "noError": "Keine",
+            "none": "keine",
             "portalId": "Portal-ID",
             "status": "Status"
         },

--- a/src/app/locales/languages/de.json
+++ b/src/app/locales/languages/de.json
@@ -100,6 +100,7 @@
             "connection": "Verbindung",
             "error": "Fehler",
             "host": "Host",
+            "noError": "Keine",
             "portalId": "Portal-ID",
             "status": "Status"
         },

--- a/src/app/locales/languages/en.json
+++ b/src/app/locales/languages/en.json
@@ -223,6 +223,7 @@
         "Diesel": "Diesel",
         "Fresh water": "Fresh water",
         "Fuel": "Fuel",
+        "Gasoline": "Gasoline",
         "Hydraulic oil": "Hydraulic oil",
         "LNG": "Liquid Natural Gas (LNG)",
         "LPG": "Liquid Petroleum Gas (LPG)",

--- a/src/app/locales/languages/en.json
+++ b/src/app/locales/languages/en.json
@@ -100,7 +100,7 @@
             "connection": "Connection",
             "error": "Error",
             "host": "Host",
-            "noError": "none",
+            "none": "none",
             "portalId": "Portal ID",
             "status": "Status"
         },

--- a/src/app/locales/languages/en.json
+++ b/src/app/locales/languages/en.json
@@ -220,10 +220,15 @@
     },
     "tankWidget": {
         "Black water": "Black water",
+        "Diesel": "Diesel",
         "Fresh water": "Fresh water",
         "Fuel": "Fuel",
+        "Hydraulic oil": "Hydraulic oil",
+        "LNG": "Liquid Natural Gas (LNG)",
+        "LPG": "Liquid Petroleum Gas (LPG)",
         "Live well": "Live well",
         "Oil": "Oil",
+        "Raw water": "Raw water",
         "Tank sensor": "Tank sensor",
         "Waste water": "Waste water"
     },

--- a/src/app/locales/languages/zh-CN.json
+++ b/src/app/locales/languages/zh-CN.json
@@ -220,10 +220,15 @@
     },
     "tankWidget": {
         "Black water": "黑水",
+        "Diesel": "柴油",
         "Fresh water": "淡水",
         "Fuel": "燃料",
+        "Hydraulic oil": "液压油",
+        "LNG": "LNG",
+        "LPG": "LPG",
         "Live well": "活鱼池",
         "Oil": "石油",
+        "Raw water": "生水",
         "Tank sensor": "水箱传感器",
         "Waste water": "废水"
     },

--- a/src/app/locales/languages/zh-CN.json
+++ b/src/app/locales/languages/zh-CN.json
@@ -100,7 +100,7 @@
             "connection": "连接",
             "error": "错误",
             "host": "主机",
-            "noError": "无",
+            "none": "无",
             "portalId": "门户ID",
             "status": "状态"
         },

--- a/src/app/locales/languages/zh-CN.json
+++ b/src/app/locales/languages/zh-CN.json
@@ -100,6 +100,7 @@
             "connection": "连接",
             "error": "错误",
             "host": "主机",
+            "noError": "无",
             "portalId": "门户ID",
             "status": "状态"
         },


### PR DESCRIPTION
Having `errorBoundary` wrapper on a component level conflicts with using `useVisibleWidgetsStore`, because in the case of an error component just isn't showed on a screen. Therefore I left `errorBoundary` only on a top App level, the same behaviour we had in previous version of MFD App.

Please pay attention, that it's not necessary anymore to wrap with `errorBoundary` any component except the main `App`.