### PR TITLE
Fix switching language for some MFD devices

### DIFF
--- a/src/app/Marine2/App.tsx
+++ b/src/app/Marine2/App.tsx
@@ -2,7 +2,7 @@ import { useAppStore, useMqtt, useTheme, useVebus, useVrmStore } from "@elninote
 import { observer } from "mobx-react"
 import React, { useEffect } from "react"
 import { withErrorBoundary } from "react-error-boundary"
-import { getLocale } from "react-i18nify"
+import { getLocale, setLocale } from "react-i18nify"
 import { useVisibleWidgetsStore } from "./modules"
 import { Marine2 } from "./Marine2"
 import Connecting from "./components/ui/Connecting"
@@ -42,7 +42,6 @@ const App = (props: AppProps) => {
     props.host,
     props.port,
     appStore.remote,
-    appStore.language,
     vrmStore.username,
     vrmStore.token,
     vrmStore.webhost,
@@ -50,6 +49,12 @@ const App = (props: AppProps) => {
     vrmStore.siteId,
     locale,
   ])
+
+  useEffect(() => {
+    if (appStore.language) {
+      setLocale(appStore.language)
+    }
+  }, [appStore.language])
 
   useEffect(() => {
     visibleWidgetsStore.clearVisibleElements()

--- a/src/app/locales/constants.ts
+++ b/src/app/locales/constants.ts
@@ -10,7 +10,13 @@ export const mfdLanguageOptions = {
   defaultLanguage: DEFAULT_LANGUAGE,
   onLangChange: (lang: string) => {
     // override the language with the value of the lang URL parameter, if present and enabled
-    const languageOverride = (window.location.search.match(/[?&]lang=([a-zA-Z-_]{2,5})/) || [])[1]
-    setLocale((process.env.REACT_APP_ENABLE_LANG_OVERRIDE === "true" && languageOverride) || lang)
+    // NB: do not rely on `lang=` param here because some MFD devices like Simrad add optional qs
+    // params with additional data, including default system `&lang=en` which overrides the language we get
+    // from mqtt in the case if app was build with REACT_APP_ENABLE_LANG_OVERRIDE flag set to true
+    // (which is usually true for debugging and demo versions)
+    const overrideLang = (window.location.search.match(/[?&]overrideLang=([a-zA-Z-_]{2,5})/) || [])[1]
+    setLocale(
+      process.env.REACT_APP_ENABLE_LANG_OVERRIDE === "true" && LANGUAGES.includes(overrideLang) ? overrideLang : lang
+    )
   },
 }

--- a/src/app/locales/constants.ts
+++ b/src/app/locales/constants.ts
@@ -12,7 +12,7 @@ export const mfdLanguageOptions = {
     // override the language with the value of the lang URL parameter, if present and enabled
     // NB: do not rely on `lang=` param here because some MFD devices like Simrad add optional qs
     // params with additional data, including default system `&lang=en` which overrides the language we get
-    // from mqtt in the case if app was build with REACT_APP_ENABLE_LANG_OVERRIDE flag set to true
+    // from mqtt in the case if app was built with REACT_APP_ENABLE_LANG_OVERRIDE flag set to true
     // (which is usually true for debugging and demo versions)
     const overrideLang = (window.location.search.match(/[?&]overrideLang=([a-zA-Z-_]{2,5})/) || [])[1]
     setLocale(


### PR DESCRIPTION
## Changes

I changed override language param for testing from `lang=` to `overrideLang=`, because some MFD devices like Simrad add optional qs params with additional data, including default system `&lang=en` which overrides the language we get from mqtt in the case if app was built with `REACT_APP_ENABLE_LANG_OVERRIDE` flag set to true (which is usually true for debugging and demo versions)

