### PR TITLE
Scale batteries progress circle inside compact box 

### DIFF
--- a/src/app/Marine2/components/boxes/DevicesOverview/DevicesOverview.tsx
+++ b/src/app/Marine2/components/boxes/DevicesOverview/DevicesOverview.tsx
@@ -94,7 +94,7 @@ const DevicesOverview = ({ mode = "full", pageSelectorPropsSetter }: Props) => {
     }
 
     if (!!instanceId) {
-      devices.push(<InverterCharger />)
+      devices.push(<InverterCharger key={instanceId} />)
     }
 
     if (!!generatorFp.phases) devices.push(<GeneratorFp generatorFp={generatorFp} />)

--- a/src/app/Marine2/components/ui/BatterySummary/BatterySummary.tsx
+++ b/src/app/Marine2/components/ui/BatterySummary/BatterySummary.tsx
@@ -38,11 +38,11 @@ const styles: BreakpointStylesType = {
   },
 }
 
-const BatterySummary = ({ battery, boxSize }: Props) => {
+const BatterySummary = ({ battery, boxSize, circleRef }: Props) => {
   const activeStyles = applyStyles(boxSize, styles)
 
   return (
-    <div className={classNames("flex flex-col justify-center items-center mx-4", activeStyles.circle)}>
+    <div className={classNames("flex flex-col justify-center items-center mx-4", activeStyles.circle)} ref={circleRef}>
       <div className={classNames("w-full", activeStyles.circleWrapper)}>
         <ProgressCircle percentage={battery.soc ?? null} boxSize={boxSize}>
           {battery.voltage || battery.voltage === 0 ? (
@@ -70,6 +70,7 @@ const BatterySummary = ({ battery, boxSize }: Props) => {
 interface Props {
   battery: Battery
   boxSize: { width: number; height: number }
+  circleRef?: React.RefObject<HTMLDivElement>
 }
 
 export default BatterySummary


### PR DESCRIPTION
I used the `transform: scale()` CSS property to scale the battery in the available box space. 

Very small horizontal split:
<img width="1248" alt="image" src="https://user-images.githubusercontent.com/119003472/228521849-1a166874-dfab-4273-b6ea-5d6d5d831006.png">

This should be supported on most of the browsers https://caniuse.com/?search=transform but I would have to test it on our devices