### PR TITLE
fix(mqtt): connect to Venus MQTT via nginx websocket

### DIFF
--- a/src/app/KVNRV/App.tsx
+++ b/src/app/KVNRV/App.tsx
@@ -25,7 +25,7 @@ const App = observer((props: AppProps) => {
     if (!appStore.remote) {
       mqtt.boot(props.host, props.port)
     } else if (appStore.remote && vrmStore?.webhost && vrmStore?.portalId && vrmStore?.siteId) {
-      mqtt.boot(vrmStore.webhost, null, true, vrmStore.portalId)
+      mqtt.boot(vrmStore.webhost, null, "", true, vrmStore.portalId)
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [props.host, props.port, appStore.remote, vrmStore.webhost, vrmStore.portalId, vrmStore.siteId, locale])

--- a/src/app/Marine2/App.tsx
+++ b/src/app/Marine2/App.tsx
@@ -28,7 +28,7 @@ const App = (props: AppProps) => {
     if (!appStore.remote) {
       mqtt.boot(props.host, props.port)
     } else if (appStore.remote && vrmStore?.webhost && vrmStore?.portalId && vrmStore?.siteId) {
-      mqtt.boot(vrmStore.webhost, null, true, vrmStore.portalId)
+      mqtt.boot(vrmStore.webhost, null, "", true, vrmStore.portalId)
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [props.host, props.port, appStore.remote, vrmStore.webhost, vrmStore.portalId, vrmStore.siteId, locale])

--- a/src/app/MarineApp/App.tsx
+++ b/src/app/MarineApp/App.tsx
@@ -25,7 +25,7 @@ const App = observer((props: AppProps) => {
     if (!appStore.remote) {
       mqtt.boot(props.host, props.port)
     } else if (appStore.remote && vrmStore?.webhost && vrmStore?.portalId && vrmStore?.siteId) {
-      mqtt.boot(vrmStore.webhost, null, true, vrmStore.portalId)
+      mqtt.boot(vrmStore.webhost, null, "", true, vrmStore.portalId)
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [props.host, props.port, appStore.remote, vrmStore.webhost, vrmStore.portalId, vrmStore.siteId, locale])

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -43,7 +43,7 @@ const getApp = () => {
 }
 
 const host = getParameterByName("host") || window.location.hostname || "localhost"
-const port = parseInt(getParameterByName("port") ?? "9001")
+const port = parseInt(getParameterByName("port") || window.location.port)
 
 const errorHandlerStore = initializeErrorHandlerStore()
 


### PR DESCRIPTION
This PR adds support to connect to Venus FlashMQ via `nginx` mapped websocket instead of using the port 9001.

It is implemented in two parts:

### 1. HTML 5 app

In the past the HTML5 app used `window.location.hostname` and hardcoded port 9001 to derive MQTT broker URL from the location where the HTML5 app is loaded. So when it is accessed remotely by connecting to Venus via `http://cerbogx/app` it would use the `cerbogx` hostname, and port 9001 to open WebSocket connection directly to FlashMQ web socket port 9001 as configured on Venus in `/etc/flashmq/flashmq.conf`.

In this new implementation it derives both hostname and port from the `window.location` and uses special request path `/websocket-mqtt` to connect to FlashMQ via Venus nginx mapping.

### 2. MFD Modules part

The MFD modules `MqttStore` allowed in the past to specify only host and port where to connect to the broker.

In the new implementation it also allows to override request path defaulting to `websocket-mqtt` so that complete broker URL can be composed. This is addressed in a separate PR here: https://github.com/victronenergy/victron-mfd-modules/pull/4