### PR TITLE
fix(alternator): display CustomName when available

### DIFF
--- a/src/app/Marine2/components/boxes/EnergyAlternator/EnergyAlternator.tsx
+++ b/src/app/Marine2/components/boxes/EnergyAlternator/EnergyAlternator.tsx
@@ -15,7 +15,7 @@ interface Props {
 }
 
 const EnergyAlternator = ({ componentMode = "compact", alternator, showInstance, compactBoxSize }: Props) => {
-  const { current, voltage } = useAlternator(alternator)
+  const { current, voltage, customName } = useAlternator(alternator)
   const instance = showInstance ? ` [${alternator}]` : ""
   const power = current * voltage
 
@@ -23,7 +23,7 @@ const EnergyAlternator = ({ componentMode = "compact", alternator, showInstance,
     return (
       <ValueOverview
         Icon={AlternatorIcon}
-        title={translate("boxes.alternator")}
+        title={customName || translate("boxes.alternator")}
         value={current}
         unit="A"
         boxSize={compactBoxSize}
@@ -33,7 +33,7 @@ const EnergyAlternator = ({ componentMode = "compact", alternator, showInstance,
 
   return (
     <ValueBox
-      title={translate("boxes.alternator") + instance}
+      title={customName || translate("boxes.alternator") + instance}
       icon={<AlternatorIcon className={responsiveBoxIcon} />}
       value={current}
       unit="A"


### PR DESCRIPTION
Closes https://github.com/victronenergy/venus-html5-app/issues/399 by extracting alernator's CustomName DBUS property and displaying that instead of default hardcoded string.

Requires https://github.com/victronenergy/victron-mfd-modules/pull/11 to be merged first.