### PR TITLE
Responsive controls

### DIFF
--- a/src/app/Marine2/components/ui/Box/Box.tsx
+++ b/src/app/Marine2/components/ui/Box/Box.tsx
@@ -64,7 +64,7 @@ const Box = ({
         className
       )}
     >
-      <div className="w-full min-w-0 min-h-[44px] flex justify-between items-center">
+      <div className="w-full min-w-0 min-h-px-44 flex justify-between items-center">
         <div
           className="w-full shrink-1 flex items-center justify-start text-victron-gray-300 dark:text-victron-gray-dark cursor-pointer min-w-0 outline-none"
           onClick={clickHandler}
@@ -73,9 +73,9 @@ const Box = ({
           <FadedText text={title} className={activeStyles?.valueSubtitle} />
         </div>
         {linkedView && (
-          <div className="-mr-3 p-[12px] cursor-pointer" onClick={clickHandler}>
+          <div className="-mr-3 w-px-44 h-px-44 p-1 cursor-pointer" onClick={clickHandler}>
             <ArrowRightIcon
-              className="w-[24px] sm-s:w-[32px] text-victron-blue dark:text-victron-blue-dark cursor-pointer outline-none"
+              className="text-victron-blue dark:text-victron-blue-dark cursor-pointer outline-none"
               alt="Expand"
             />
           </div>

--- a/src/app/Marine2/components/ui/Footer/Footer.tsx
+++ b/src/app/Marine2/components/ui/Footer/Footer.tsx
@@ -18,7 +18,7 @@ const Footer = ({ pageSelectorProps }: Props) => {
   }, [appViewsStore.currentView])
 
   return (
-    <div className="flex flex-row w-full h-16 items-center justify-between pt-2 pb-3">
+    <div className="flex flex-row w-full h-px-44 m-1 items-center justify-between pt-2 pb-3">
       <div className="flex flex-1 flex-row items-center justify-between">
         <VersionInfo />
         {!!pageSelectorProps && !!pageSelectorProps.maxPages && pageSelectorProps.maxPages > 1 && (
@@ -27,7 +27,7 @@ const Footer = ({ pageSelectorProps }: Props) => {
           </div>
         )}
         {isShowBack && (
-          <div onClick={handleBackClick} className={"w-fit h-fit cursor-pointer"}>
+          <div onClick={handleBackClick} className={"w-px-44 h-px-44 p-1 cursor-pointer"}>
             <BackIcon onClick={handleBackClick} className={"text-blue-600 dark:text-blue-400"} alt={"Back"} />
           </div>
         )}

--- a/src/app/Marine2/components/ui/PageSelector/DotIcon/index.tsx
+++ b/src/app/Marine2/components/ui/PageSelector/DotIcon/index.tsx
@@ -10,12 +10,12 @@ interface DotProps {
 
 export const DotIcon: FC<DotProps> = ({ isCurrentPage, isHorizontal }) => {
   if (isCurrentPage && isHorizontal) {
-    return <DotSelectedIcon className="text-victron-darkGray dark:text-white" />
+    return <DotSelectedIcon className="w-px-16 h-px-8 text-victron-darkGray dark:text-white" />
   }
 
   if (isCurrentPage && !isHorizontal) {
-    return <DotSelectedVerticalIcon className="text-victron-darkGray dark:text-white" />
+    return <DotSelectedVerticalIcon className="w-px-8 h-px-16 text-victron-darkGray dark:text-white" />
   }
 
-  return <PlainDotIcon className="text-victron-gray dark:text-victron-gray-400" />
+  return <PlainDotIcon className="w-px-8 h-px-8 text-victron-gray dark:text-victron-gray-400" />
 }

--- a/src/app/Marine2/components/ui/PageSelector/PageSelector.tsx
+++ b/src/app/Marine2/components/ui/PageSelector/PageSelector.tsx
@@ -75,7 +75,7 @@ const PageSelector = ({
   return (
     <div
       className={classnames("flex items-center select-none", {
-        "h-[44px] w-full min-w-[140px]": isHorizontal,
+        "h-px-44 w-full min-w-[140px]": isHorizontal,
         "w-11 h-full min-h-[140px] flex-col": !isHorizontal,
         "justify-between": selectorLocation.endsWith("full"),
         "justify-end": selectorLocation.endsWith("right") || selectorLocation.endsWith("bottom"),

--- a/src/app/Marine2/components/ui/PageSelector/SelectorButton/index.tsx
+++ b/src/app/Marine2/components/ui/PageSelector/SelectorButton/index.tsx
@@ -13,7 +13,7 @@ interface Props {
 }
 
 export const SelectorButton: FC<Props> = ({ onClick, direction, disabled, isHorizontal }) => {
-  const buttonClasses = "w-[44px] h-[44px] shrink-0 cursor-pointer"
+  const buttonClasses = "w-px-44 h-px-44 shrink-0 cursor-pointer"
   const iconClasses = classNames({
     "text-victron-gray dark:text-victron-gray-dark": disabled,
     "text-victron-blue dark:text-victron-blue-dark": !disabled,

--- a/src/app/Marine2/components/ui/RadioButton/RadioButton.tsx
+++ b/src/app/Marine2/components/ui/RadioButton/RadioButton.tsx
@@ -16,20 +16,20 @@ const RadioButton: React.FC<Props> = ({ selected, onChange, disabled, responsive
         onClick={() => !disabled && onChange()}
         className={classNames(
           // we especially use `px` here to avoid UI issues on some MFD screens
-          "w-[24px] h-[24px] border-[2px] bg-inherit rounded-full flex items-center justify-center",
+          "w-px-24 h-px-24 border-px-2 bg-inherit rounded-full flex items-center justify-center",
           {
             "border-victron-gray": !selected,
             "border-victron-blue": selected,
-            "md-m:w-[24px] md-m:h-[24px] md-m:border-[2px]": true, // large
-            "sm-s:w-[16px] sm-s:h-[16px] sm-s:border-[1px]": responsive, // small
+            "md-m:w-px-24 md-m:h-px-24 md-m:border-px-2": true, // large
+            "sm-s:w-px-16 sm-s:h-px-16 sm-s:border-px-1": responsive, // small
           }
         )}
       >
         {selected && (
           <div
-            className={classNames("w-[16px] h-[16px] rounded-full bg-victron-blue", {
-              "md-m:w-[16px] md-m:h-[16px]": true, // large
-              "sm-s:w-[8px] sm-s:h-[8px]": responsive, // small
+            className={classNames("w-px-16 h-px-16 rounded-full bg-victron-blue", {
+              "md-m:w-px-16 md-m:h-px-16": true, // large
+              "sm-s:w-px-8 sm-s:h-px-8": responsive, // small
             })}
           ></div>
         )}

--- a/src/app/Marine2/components/ui/SettingsMenu/SettingsMenu.tsx
+++ b/src/app/Marine2/components/ui/SettingsMenu/SettingsMenu.tsx
@@ -52,16 +52,16 @@ const SettingsMenu = () => {
   }
 
   return (
-    <div className="dark:text-white cursor-pointer w-[64px] outline-none" onClick={() => setIsModalOpen(!isModalOpen)}>
+    <div className="dark:text-white cursor-pointer outline-none" onClick={() => setIsModalOpen(!isModalOpen)}>
       <div className="flex justify-center items-center w-full">
         {!isModalOpen ? (
           <div className="h-full">
-            <PreferencesIcon alt={"Settings"} />
+            <PreferencesIcon className="w-px-44 h-px-44 justify-center p-3" alt={"Settings"} />
           </div>
         ) : (
           <>
             <CloseIcon
-              className="w-[32px] ml-auto mr-2 opacity-1 z-20 text-white dark:text-victron-blue"
+              className="w-px-44 h-px-44 justify-center p-3 opacity-1 z-20 text-white dark:text-victron-blue"
               onClick={() => setIsModalOpen(false)}
             />
           </>

--- a/src/app/Marine2/components/ui/ToggleSwitch/ToggleSwitch.tsx
+++ b/src/app/Marine2/components/ui/ToggleSwitch/ToggleSwitch.tsx
@@ -19,8 +19,8 @@ const ToggleSwitch: React.FC<Props> = ({ id, onChange, selected, disabled }) => 
         checked={selected}
         disabled={disabled}
       />
-      <div className="w-[36px] h-[16px] sm-l:w-[44px] sm-l:h-[20px] rounded-full shadow border-victron-gray border-[2px] peer-checked:bg-victron-blue peer-checked:border-victron-blue bg-victron-gray-600 dark:bg-transparent"></div>
-      <div className="absolute left-0 w-[20px] h-[20px] sm-l:w-[24px] sm-l:h-[24px] rounded-full shadow -inset-y-[2px] bg-white peer-checked:right-0 peer-checked:left-auto"></div>
+      <div className="w-px-36 h-px-16 sm-l:w-px-44 sm-l:h-px-20 rounded-full shadow border-victron-gray border-px-2 peer-checked:bg-victron-blue peer-checked:border-victron-blue bg-victron-gray-600 dark:bg-transparent"></div>
+      <div className="absolute left-0 w-px-20 h-px-20 sm-l:w-px-24 sm-l:h-px-24 rounded-full shadow -inset-y-px-2 bg-white peer-checked:right-0 peer-checked:left-auto"></div>
     </span>
   )
 }

--- a/src/app/Marine2/css/global.css
+++ b/src/app/Marine2/css/global.css
@@ -7,46 +7,130 @@
     font-family: MuseoSans, "Noto Sans SC", sans-serif;
   }
 
-  /* Specify the base font size according to device horizontal resolution,
-     assuming it will be in one of 4:3 or 16:9 standard screen formats,
-     and adjust the font size appropriately */
-
-  /* All screen resolutions up to 1900 x 900 (slightly smaller 1/4 of 4k) */
+  /* All screen resolutions up to 1920 x 1080p (Full HD) */
+  :root {
+    /* UI scale factor */
+    --uix: 1.0;
+    --px1: var(--uix);
+    --px2: calc(var(--uix) * 2px);
+    --px8: calc(var(--uix) * 8px);
+    --px16: calc(var(--uix) * 16px);
+    --px20: calc(var(--uix) * 20px);
+    --px24: calc(var(--uix) * 24px);
+    --px32: calc(var(--uix) * 32px);
+    --px36: calc(var(--uix) * 36px);
+    --px44: calc(var(--uix) * 44px);
+  }
   html {
     font-size: 16px;
   }
 
   /* 1900 x 900 (slightly smaller 1/4 of 4k) up to 2560 × 1440p (2.5k / QHD) */
+  /* 1.25 x base size */
   @media screen and (min-width: 1900px) and (max-width: 2559px) {
+    :root {
+      --uix: 1.25;
+      --px1: var(--uix);
+      --px2: calc(var(--uix) * 2px);
+      --px8: calc(var(--uix) * 8px);
+      --px16: calc(var(--uix) * 16px);
+      --px20: calc(var(--uix) * 20px);
+      --px24: calc(var(--uix) * 24px);
+      --px32: calc(var(--uix) * 32px);
+      --px36: calc(var(--uix) * 36px);
+      --px44: calc(var(--uix) * 44px);
+      }
     html {
       font-size: 20px;
     }
   }
   @media screen and (min-height: 900px) and (max-height: 1439px) {
+    :root {
+      --uix: 1.25;
+      --px1: var(--uix);
+      --px2: calc(var(--uix) * 2px);
+      --px8: calc(var(--uix) * 8px);
+      --px16: calc(var(--uix) * 16px);
+      --px20: calc(var(--uix) * 20px);
+      --px24: calc(var(--uix) * 24px);
+      --px32: calc(var(--uix) * 32px);
+      --px36: calc(var(--uix) * 36px);
+      --px44: calc(var(--uix) * 44px);
+      }
     html {
         font-size: 20px;
     }
   }
 
   /* 2560 × 1440p (2.5k / QHD) up to 3840 × 2160p (4k / UHD) (minus ~10% vertically) */
+  /* 1.625 x base size */
   @media screen and (min-width: 2560px) and (max-width: 3839px) {
+    :root {
+      --uix: 1.625;
+      --px1: var(--uix);
+      --px2: calc(var(--uix) * 2px);
+      --px8: calc(var(--uix) * 8px);
+      --px16: calc(var(--uix) * 16px);
+      --px20: calc(var(--uix) * 20px);
+      --px24: calc(var(--uix) * 24px);
+      --px32: calc(var(--uix) * 32px);
+      --px36: calc(var(--uix) * 36px);
+      --px44: calc(var(--uix) * 44px);
+      }
     html {
         font-size: 26px;
     }
   }
   @media screen and (min-height: 1440px) and (max-height: 1981px) {
+    :root {
+      --uix: 1.625;
+      --px1: var(--uix);
+      --px2: calc(var(--uix) * 2px);
+      --px8: calc(var(--uix) * 8px);
+      --px16: calc(var(--uix) * 16px);
+      --px20: calc(var(--uix) * 20px);
+      --px24: calc(var(--uix) * 24px);
+      --px32: calc(var(--uix) * 32px);
+      --px36: calc(var(--uix) * 36px);
+      --px44: calc(var(--uix) * 44px);
+      }
     html {
         font-size: 26px;
     }
   }
 
   /* 3840 × 2160p (4K / UHD) (minus ~10% vertically) and up */
+  /* 2.0 x base size */
   @media screen and (min-width: 3840px) {
+    :root {
+      --uix: 2.0;
+      --px1: var(--uix);
+      --px2: calc(var(--uix) * 2px);
+      --px8: calc(var(--uix) * 8px);
+      --px16: calc(var(--uix) * 16px);
+      --px20: calc(var(--uix) * 20px);
+      --px24: calc(var(--uix) * 24px);
+      --px32: calc(var(--uix) * 32px);
+      --px36: calc(var(--uix) * 36px);
+      --px44: calc(var(--uix) * 44px);
+      }
     html {
         font-size: 32px;
     }
   }
   @media screen and (min-height: 1982px) {
+    :root {
+      --uix: 2.0;
+      --px1: var(--uix);
+      --px2: calc(var(--uix) * 2px);
+      --px8: calc(var(--uix) * 8px);
+      --px16: calc(var(--uix) * 16px);
+      --px20: calc(var(--uix) * 20px);
+      --px24: calc(var(--uix) * 24px);
+      --px32: calc(var(--uix) * 32px);
+      --px36: calc(var(--uix) * 36px);
+      --px44: calc(var(--uix) * 44px);
+      }
     html {
         font-size: 32px;
     }

--- a/src/app/Marine2/images/icons/back.svg
+++ b/src/app/Marine2/images/icons/back.svg
@@ -1,3 +1,3 @@
-<svg width="42" height="42" viewBox="0 0 42 42" fill="none" xmlns="http://www.w3.org/2000/svg">
+<svg viewBox="0 0 42 42" fill="none" xmlns="http://www.w3.org/2000/svg">
 <path d="M5.25 33.25L25.375 33.25C31.6572 33.25 36.75 28.1572 36.75 21.875V21.875C36.75 15.5928 31.6572 10.5 25.375 10.5L5.25 10.5M5.25 10.5L10.5 5.25M5.25 10.5L10.5 15.75" stroke="#387DC5" stroke-width="2" stroke-linecap="round"/>
 </svg>

--- a/src/app/Marine2/images/icons/preferences.svg
+++ b/src/app/Marine2/images/icons/preferences.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="6" height="26" viewBox="0 0 6 26" fill="none">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 6 26" fill="none">
   <circle cx="3" cy="3" r="3" fill="#387DC5"/>
   <circle cx="3" cy="13" r="3" fill="#387DC5"/>
   <circle cx="3" cy="23" r="3" fill="#387DC5"/>

--- a/src/app/Marine2/images/icons/selectors/dot-selected-vert.svg
+++ b/src/app/Marine2/images/icons/selectors/dot-selected-vert.svg
@@ -1,3 +1,3 @@
-<svg width="8" height="16" viewBox="0 0 8 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+<svg viewBox="0 0 8 16" fill="none" xmlns="http://www.w3.org/2000/svg">
 <path d="M4 12L4 4" stroke="currentColor" stroke-width="8" stroke-linecap="round"/>
 </svg>

--- a/src/app/Marine2/images/icons/selectors/dot-selected.svg
+++ b/src/app/Marine2/images/icons/selectors/dot-selected.svg
@@ -1,3 +1,3 @@
-<svg width="16" height="8" viewBox="0 0 16 8" fill="none" xmlns="http://www.w3.org/2000/svg">
+<svg viewBox="0 0 16 8" fill="none" xmlns="http://www.w3.org/2000/svg">
 <path d="M4 4H12" stroke="currentColor" stroke-width="8" stroke-linecap="round"/>
 </svg>

--- a/src/app/Marine2/images/icons/selectors/dot.svg
+++ b/src/app/Marine2/images/icons/selectors/dot.svg
@@ -1,3 +1,3 @@
-<svg width="8" height="8" viewBox="0 0 8 8" fill="none" xmlns="http://www.w3.org/2000/svg">
+<svg viewBox="0 0 8 8" fill="none" xmlns="http://www.w3.org/2000/svg">
 <circle cx="4" cy="4" r="4" fill="currentColor"/>
 </svg>

--- a/src/app/Marine2/images/icons/selectors/selector-down.svg
+++ b/src/app/Marine2/images/icons/selectors/selector-down.svg
@@ -1,4 +1,4 @@
-<svg width="42" height="42" viewBox="0 0 42 42" fill="none" xmlns="http://www.w3.org/2000/svg">
+<svg viewBox="0 0 42 42" fill="none" xmlns="http://www.w3.org/2000/svg">
 <rect width="42" height="42" rx="8" transform="matrix(0 1 1 0 0 0)" fill="currentColor" fill-opacity="0.3"/>
 <path fill-rule="evenodd" clip-rule="evenodd" d="M9.29289 16.7071C8.90237 16.3166 8.90237 15.6834 9.29289 15.2929C9.68342 14.9024 10.3166 14.9024 10.7071 15.2929L21 25.5858L31.2929 15.2929C31.6834 14.9024 32.3166 14.9024 32.7071 15.2929C33.0976 15.6834 33.0976 16.3166 32.7071 16.7071L21.7071 27.7071C21.3166 28.0976 20.6834 28.0976 20.2929 27.7071L9.29289 16.7071Z" fill="currentColor"/>
 </svg>

--- a/src/app/Marine2/images/icons/selectors/selector-left.svg
+++ b/src/app/Marine2/images/icons/selectors/selector-left.svg
@@ -1,4 +1,4 @@
-<svg width="42" height="42" viewBox="0 0 42 42" fill="none" xmlns="http://www.w3.org/2000/svg">
+<svg viewBox="0 0 42 42" fill="none" xmlns="http://www.w3.org/2000/svg">
 <rect width="42" height="42" rx="8" transform="matrix(-1 0 0 1 42 0)" fill="currentColor" fill-opacity="0.3"/>
 <path fill-rule="evenodd" clip-rule="evenodd" d="M25.2929 9.29289C25.6834 8.90237 26.3166 8.90237 26.7071 9.29289C27.0976 9.68342 27.0976 10.3166 26.7071 10.7071L16.4142 21L26.7071 31.2929C27.0976 31.6834 27.0976 32.3166 26.7071 32.7071C26.3166 33.0976 25.6834 33.0976 25.2929 32.7071L14.2929 21.7071C13.9024 21.3166 13.9024 20.6834 14.2929 20.2929L25.2929 9.29289Z" fill="currentColor"/>
 </svg>

--- a/src/app/Marine2/images/icons/selectors/selector-right.svg
+++ b/src/app/Marine2/images/icons/selectors/selector-right.svg
@@ -1,4 +1,4 @@
-<svg width="42" height="42" viewBox="0 0 42 42" fill="none" xmlns="http://www.w3.org/2000/svg">
+<svg viewBox="0 0 42 42" fill="none" xmlns="http://www.w3.org/2000/svg">
 <rect width="42" height="42" rx="8" fill="currentColor" fill-opacity="0.3"/>
 <path fill-rule="evenodd" clip-rule="evenodd" d="M16.7071 9.29289C16.3166 8.90237 15.6834 8.90237 15.2929 9.29289C14.9024 9.68342 14.9024 10.3166 15.2929 10.7071L25.5858 21L15.2929 31.2929C14.9024 31.6834 14.9024 32.3166 15.2929 32.7071C15.6834 33.0976 16.3166 33.0976 16.7071 32.7071L27.7071 21.7071C28.0976 21.3166 28.0976 20.6834 27.7071 20.2929L16.7071 9.29289Z" fill="currentColor"/>
 </svg>

--- a/src/app/Marine2/images/icons/selectors/selector-up.svg
+++ b/src/app/Marine2/images/icons/selectors/selector-up.svg
@@ -1,4 +1,4 @@
-<svg width="42" height="42" viewBox="0 0 42 42" fill="none" xmlns="http://www.w3.org/2000/svg">
+<svg viewBox="0 0 42 42" fill="none" xmlns="http://www.w3.org/2000/svg">
 <rect y="42" width="42" height="42" rx="8" transform="rotate(-90 0 42)" fill="currentColor" fill-opacity="0.3"/>
 <path fill-rule="evenodd" clip-rule="evenodd" d="M9.29289 25.2929C8.90237 25.6834 8.90237 26.3166 9.29289 26.7071C9.68342 27.0976 10.3166 27.0976 10.7071 26.7071L21 16.4142L31.2929 26.7071C31.6834 27.0976 32.3166 27.0976 32.7071 26.7071C33.0976 26.3166 33.0976 25.6834 32.7071 25.2929L21.7071 14.2929C21.3166 13.9024 20.6834 13.9024 20.2929 14.2929L9.29289 25.2929Z" fill="currentColor"/>
 </svg>

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -126,6 +126,21 @@ module.exports = {
       fontFamily: {
         sans: ["MuseoSans", ...defaultTheme.fontFamily.sans],
       },
+      spacing: {
+        "px-1": "var(--px1)",
+        "px-2": "var(--px2)",
+        "px-8": "var(--px8)",
+        "px-16": "var(--px16)",
+        "px-20": "var(--px20)",
+        "px-24": "var(--px24)",
+        "px-32": "var(--px32)",
+        "px-36": "var(--px36)",
+        "px-44": "var(--px44)",
+      },
+      borderWidth: {
+        "px-1": "var(--px1)",
+        "px-2": "var(--px2)",
+      },
       borderRadius: {
         none: "0",
         sm: "0.25rem",


### PR DESCRIPTION
This PR closes https://github.com/victronenergy/venus-html5-app/issues/470. I chose the following approach:

- [x] Removed all hardcoded `width` and `height` attributes from `.svg` files to make them resizable as intended.
- [x] Added `--uix` CSS variable with default value of `1.0` and going in steps up to `2.0` for 4k displays.
- [x] Added custom `--px-X` CSS variables scaling up hard coded pixel values with `--uix`.
- [x] Added `tailwindcss` overrides for `spacing` and `borderWidth` using these CSS `--px-X` variables. 
- [x] Changed the size of Page Selector.
- [x] Changed the size of Settings, Close, and Back buttons.
- [x] Changed the size of drill down right arrow button.
- [x] Changed the size of RadioButton and ToggleSwitch.

Here are the remaining things I would like to address:

- [ ] Verify various other elements for their px hard coded sizes.