### PR TITLE
feat: Add support for night mode

### DIFF
--- a/src/app/Marine2/components/ui/SettingsMenu/SettingsMenu.tsx
+++ b/src/app/Marine2/components/ui/SettingsMenu/SettingsMenu.tsx
@@ -37,6 +37,17 @@ const SettingsMenu = () => {
     }
   }, [])
 
+  const setNightMode = () => {
+    // TODO: when light mode is on, turn on dark/red
+    // TODO: when dark mode is on, turn on/off dark/normal dark/red
+    // const mediaQuery = window.matchMedia("(prefers-color-scheme: dark)")
+    // if (mediaQuery.matches && !themeStore.darkMode) {
+    //   themeStore.setDarkMode(true)
+    // } else if (!mediaQuery.matches && themeStore.darkMode) {
+    //   themeStore.setDarkMode(false)
+    // }
+  }
+
   const setAutoMode = () => {
     const mediaQuery = window.matchMedia("(prefers-color-scheme: dark)")
 
@@ -109,9 +120,15 @@ const SettingsMenu = () => {
               </label>
               <label className="flex justify-between items-center pb-4 sm-m:pb-6 sm-l:pb-8">
                 <span className="mr-1 text-sm sm-m:mr-2 sm-l:text-base text-black dark:text-white">
+                  {translate("common.night")}
+                </span>
+                <ToggleSwitch id="ToggleNightMde" onChange={setNightMode} />
+              </label>
+              <label className="flex justify-between items-center pb-4 sm-m:pb-6 sm-l:pb-8">
+                <span className="mr-1 text-sm sm-m:mr-2 sm-l:text-base text-black dark:text-white">
                   {translate("common.auto")}
                 </span>
-                <ToggleSwitch id="Toggle2" onChange={setAutoMode} />
+                <ToggleSwitch id="ToggleAutoMode" onChange={setAutoMode} />
               </label>
               <Button onClick={openRemoteConsole} className="w-full" size="md">
                 {translate("header.remoteConsole")}

--- a/src/app/Marine2/components/ui/SettingsMenu/SettingsMenu.tsx
+++ b/src/app/Marine2/components/ui/SettingsMenu/SettingsMenu.tsx
@@ -122,7 +122,7 @@ const SettingsMenu = () => {
                 <span className="mr-1 text-sm sm-m:mr-2 sm-l:text-base text-black dark:text-white">
                   {translate("common.night")}
                 </span>
-                <ToggleSwitch id="ToggleNightMde" onChange={setNightMode} />
+                <RadioButton onChange={() => themeStore.setNightMode(true)} selected={themeStore.nightMode} />
               </label>
               <label className="flex justify-between items-center pb-4 sm-m:pb-6 sm-l:pb-8">
                 <span className="mr-1 text-sm sm-m:mr-2 sm-l:text-base text-black dark:text-white">

--- a/src/app/locales/languages/en.json
+++ b/src/app/locales/languages/en.json
@@ -82,7 +82,7 @@
         "minutes": "minutes",
         "minutes_short": "m",
         "mode": "Mode",
-        "night": "Prefer Night Dark Mode",
+        "night": "Night",
         "noShorePower": "No Shore Power",
         "notAvailable": "Not Available",
         "grid": "Grid",

--- a/src/app/locales/languages/en.json
+++ b/src/app/locales/languages/en.json
@@ -82,6 +82,7 @@
         "minutes": "minutes",
         "minutes_short": "m",
         "mode": "Mode",
+        "night": "Prefer Night Dark Mode",
         "noShorePower": "No Shore Power",
         "notAvailable": "Not Available",
         "grid": "Grid",


### PR DESCRIPTION
This PR addresses https://github.com/victronenergy/venus-html5-app/issues/369. 

It requires multiple steps:

- [ ] Add support for night mode to `Theme.store` in mfd-modules, tracked via https://github.com/victronenergy/victron-mfd-modules/pull/22
- [ ] Extract all theme colors defined in `tailwind.config.js` into CSS variables with semantic names defined in `global.css`
- [ ] Define color variants via CSS variables for `light`, `dark`, and `dark-red` 
- [ ] Modify theme handling to toggle between `light`, `dark`, and `dark-red` via top level element CSS class
- [ ] Remove all use of tailwindcss `dark:` prefix to only ever use single semantic colors everywhere. This simplifies the theme handling and specifies only one semantic foreground and background color.

The following issues are still unresolved:

- [ ] Figure out how the `Auto` vs. `Light/Dark` should behave with respect to `Night` theme. When `Auto` is selected, system switches between `Light` and `Dark`, when `Night` is selected we should probably turn off `Auto` mode, or make `Auto` a sub-mode of `Dark` via Toggle.