### PR TITLE
Fix generator data not shown properly

### DIFF
--- a/src/app/Marine2/components/boxes/DevicesOverview/DevicesOverview.tsx
+++ b/src/app/Marine2/components/boxes/DevicesOverview/DevicesOverview.tsx
@@ -193,6 +193,7 @@ const getAvailableDeviceBoxes = function (
         <GeneratorRelay
           key="generator_relay"
           {...generatorRelay}
+          active={generatorRelay.statusCode === 1}
           componentMode={componentMode}
           compactBoxSize={compactBoxSize}
         />

--- a/src/app/Marine2/components/boxes/GeneratorRelay/GeneratorRelay.tsx
+++ b/src/app/Marine2/components/boxes/GeneratorRelay/GeneratorRelay.tsx
@@ -38,7 +38,7 @@ const GeneratorRelay = ({
   compactBoxSize,
 }: Props) => {
   const title = translate("widgets.generator")
-  const subTitle = generatorStateFor(statusCode, active, phases)
+  const subTitle = generatorStateFor(statusCode, active)
 
   const { electricalPowerIndicator } = useAppStore()
   const { current, voltage, power } = useActiveInValues()

--- a/src/app/Marine2/utils/formatters/devices/generator-relay/generator-state-for.ts
+++ b/src/app/Marine2/utils/formatters/devices/generator-relay/generator-state-for.ts
@@ -1,9 +1,8 @@
 import { translate } from "react-i18nify"
-import { isSinglePhaseFor } from "../../../helpers/is-single-phase-for"
 
-export const generatorStateFor = (value: number, active: boolean = false, phases: number) => {
+export const generatorStateFor = (value: number, active: boolean = false) => {
   if (active) {
-    return isSinglePhaseFor(phases) ? translate("common.running") : translate("common.nrOfPhases", { phases })
+    return translate("common.running")
   }
 
   switch (value) {


### PR DESCRIPTION
Closes https://github.com/victronenergy/venus-html5-app/issues/477 by inferring the `active` property of the relay controlled generator from its `statusCode`. 

Also simplifies generator state reporting to only ever show `Running`, `Stopped`, and `Error` (if available via generator status code).