### PR TITLE
feat: disable animations when opening GUI-v2 via RemoteConsole

### DIFF
--- a/src/app/Marine2/components/ui/RemoteConsole/RemoteConsole.tsx
+++ b/src/app/Marine2/components/ui/RemoteConsole/RemoteConsole.tsx
@@ -32,7 +32,7 @@ const RemoteConsole = ({ host, width, height }: Props) => {
 
   const protocol = (typeof window !== "undefined" && window.location.protocol) || "http:"
   const colorScheme = themeStore.autoMode ? "auto" : themeStore.darkMode ? "dark" : "light"
-  const iframeUrl = `${protocol}//${host}/?fullscreen&colorScheme=${colorScheme}`
+  const iframeUrl = `${protocol}//${host}/?fullscreen&colorScheme=${colorScheme}&animationEnabled=false`
   const qrCodeUrl = `${window.location.protocol}//venus.local/`
 
   if (app.guiVersion !== 1 && browserFeatures.isGuiV2Supported === false) {


### PR DESCRIPTION
This PR addresses possible GUI-v2 lockups on slower MFD devices by disabling all animations. 

Closes #549, by relying on https://github.com/victronenergy/gui-v2/pull/3045/