### PR TITLE
fix: persist SwitchingPane page across view switches, auto close color picker

### DIFF
--- a/src/app/Marine2/components/ui/ColorPicker/ColorPicker.tsx
+++ b/src/app/Marine2/components/ui/ColorPicker/ColorPicker.tsx
@@ -53,6 +53,7 @@ interface ColorPickerProps {
   onRGBColorPresetsChange?: (presets: HSVWColorPresets) => void
   onRGBWColorPresetsChange?: (presets: HSVWColorPresets) => void
   onCCTColorPresetsChange?: (presets: HSVWColorPresets) => void
+  open?: boolean
   className?: string
 }
 
@@ -69,6 +70,7 @@ const ColorPicker = observer(
     onRGBColorPresetsChange,
     onRGBWColorPresetsChange,
     onCCTColorPresetsChange,
+    open,
     className = "",
   }: ColorPickerProps) => {
     // Cache color prop for local re-rendering
@@ -81,6 +83,14 @@ const ColorPicker = observer(
     const [localColorPresets, setLocalColorPresets] = useState<HSVWColorPresets>(emptyHSVWColorPresets)
 
     useLayoutEffect(() => {
+      if (
+        isDraggingHueRef.current ||
+        isDraggingBrightnessRef.current ||
+        isDraggingSaturationRef.current ||
+        isDraggingWhiteLevelRef.current
+      ) {
+        return
+      }
       setLocalColor(color)
     }, [color])
 
@@ -405,23 +415,23 @@ const ColorPicker = observer(
           }
           if (isInRGBMode) {
             const newHue = calculateHue(angle)
-            updateColorDebounced({ ...color, hue: createHue(newHue) })
+            updateColorDebounced({ ...localColor, hue: createHue(newHue) })
             event.preventDefault()
           }
         }
         if (isDraggingBrightnessRef.current) {
           const newBrightness = calculateBrightness(angle)
-          updateColorDebounced({ ...color, brightness: createPercentage(newBrightness) })
+          updateColorDebounced({ ...localColor, brightness: createPercentage(newBrightness) })
           event.preventDefault()
         }
         if (isDraggingSaturationRef.current) {
           const newSaturation = calculateSaturation(angle)
-          updateColorDebounced({ ...color, saturation: createPercentage(newSaturation) })
+          updateColorDebounced({ ...localColor, saturation: createPercentage(newSaturation) })
           event.preventDefault()
         }
         if (isDraggingWhiteLevelRef.current) {
           const newWhiteLevel = calculateWhiteLevel(angle)
-          updateColorDebounced({ ...color, white: createPercentage(newWhiteLevel) })
+          updateColorDebounced({ ...localColor, white: createPercentage(newWhiteLevel) })
           event.preventDefault()
         }
       },
@@ -434,7 +444,6 @@ const ColorPicker = observer(
         updateColorDebounced,
         localColor,
         calculateHue,
-        color,
         calculateBrightness,
         calculateSaturation,
         calculateWhiteLevel,
@@ -490,6 +499,10 @@ const ColorPicker = observer(
     }, [containerWidth, containerHeight])
 
     const [isEditingPresets, setIsEditingPresets] = useState(false)
+
+    useEffect(() => {
+      if (open === false) setIsEditingPresets(false)
+    }, [open])
 
     const toggleIsEdittingPresets = useCallback(() => {
       setIsEditingPresets(!isEditingPresets)

--- a/src/app/Marine2/components/ui/GroupPaginator/GroupPaginator.tsx
+++ b/src/app/Marine2/components/ui/GroupPaginator/GroupPaginator.tsx
@@ -17,6 +17,7 @@ const GroupPaginator = <T extends React.JSX.Element>({
   childrenGroups,
   orientation = "horizontal",
   selectorLocation = "bottom-center",
+  pageNumber,
   currentPageSetter = (_currentPage, _pageCount) => {},
 }: Props<T>) => {
   const wrapperRef = useRef<HTMLDivElement>(null)
@@ -24,7 +25,7 @@ const GroupPaginator = <T extends React.JSX.Element>({
 
   const [pagingResults, setPagingResults] = useState<Pages<T>[]>([])
   const [pageCount, setPageCount] = useState(0)
-  const [currentPage, setCurrentPage] = useState(0)
+  const [currentPage, setCurrentPage] = useState(pageNumber ?? 0)
 
   const groupsOfChildrenToMeasure = useMemo(() => {
     return childrenGroups.map((group) => {

--- a/src/app/Marine2/components/ui/Modal/Modal.tsx
+++ b/src/app/Marine2/components/ui/Modal/Modal.tsx
@@ -7,12 +7,13 @@ interface Props {
   onClose: () => void
   children: ReactNode
   className?: string
+  preserveLayout?: boolean
 }
 
-const Frame: FC<Props> = ({ children, open = true, onClose, className }) => {
+const Frame: FC<Props> = ({ children, open = true, onClose, className, preserveLayout = false }) => {
   const classes = classNames(
     "fixed inset-0 z-10 p-4 md:p-8 text-content-secondary modal items-center justify-center",
-    `${open ? "flex" : "hidden"}`, // control visibility via `open` attribute (or render conditionally)
+    preserveLayout ? { flex: true, "invisible pointer-events-none opacity-0": !open } : { hidden: !open, flex: open },
   )
   return (
     <div className={classes} onClick={onClose}>

--- a/src/app/Marine2/components/ui/PageFlipper/PageFlipper.tsx
+++ b/src/app/Marine2/components/ui/PageFlipper/PageFlipper.tsx
@@ -19,7 +19,11 @@ const PageFlipper = ({
   const pageRef = useRef<HTMLDivElement>(null)
   const [width, height] = useSize(wrapperRef)
   const [currentPage, setCurrentPage] = useState(startingPage ?? 0)
-  const [cachedCurrentPage] = useState(startingPage ?? 0)
+  const currentPageRef = useRef(startingPage ?? 0)
+
+  useLayoutEffect(() => {
+    currentPageRef.current = currentPage
+  }, [currentPage])
 
   useLayoutEffect(() => {
     if (pageSelectorPropsSetter) {
@@ -32,14 +36,14 @@ const PageFlipper = ({
     }
   }, [currentPage, pageSelectorPropsSetter, pages])
 
-  // Restore scroll position to cachedCurrentPage when viewport changes
+  // Restore scroll position when viewport changes (e.g. modal hidden→visible)
   useLayoutEffect(() => {
     if (!pageRef.current) {
       return
     }
-    const offset = cachedCurrentPage * pageRef.current.offsetWidth
+    const offset = currentPageRef.current * pageRef.current.offsetWidth
     pageRef.current.scrollLeft = offset
-  }, [width, height, cachedCurrentPage])
+  }, [width, height])
 
   // Smooth scroll to new position when currentPage changes
   useLayoutEffect(() => {

--- a/src/app/Marine2/components/ui/SwitchableOutput/DimmableHSVWOutput.tsx
+++ b/src/app/Marine2/components/ui/SwitchableOutput/DimmableHSVWOutput.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useMemo, useRef, useState } from "react"
+import React, { useCallback, useContext, useEffect, useMemo, useRef, useState } from "react"
 import {
   getSwitchingPaneItemNameForDisplay,
   SwitchableOutputId,
@@ -30,6 +30,7 @@ import { Modal } from "../Modal"
 import CloseIcon from "../../../images/icons/close.svg"
 import FadedText from "../FadedText"
 import ColorPicker, { ColorPickerMode, ColorPickerValidModes } from "../ColorPicker/ColorPicker"
+import { SwitchingPaneContext } from "../../views/SwitchingPaneContext"
 
 interface DimmableHSVWOutputProps {
   key: string
@@ -165,6 +166,11 @@ const DimmableHSVWOutput = observer((props: DimmableHSVWOutputProps) => {
   )
 
   const [isColorWheelOpen, setIsColorWheelOpen] = useState(false)
+  const { isOpen: isSwitchingPaneOpen } = useContext(SwitchingPaneContext)
+
+  useEffect(() => {
+    if (!isSwitchingPaneOpen) setIsColorWheelOpen(false)
+  }, [isSwitchingPaneOpen])
 
   const isInCCTMode = switchableOutput.type === SWITCHABLE_OUTPUT_TYPE.CCT_COLOR_WHEEL
 
@@ -314,6 +320,7 @@ const DimmableHSVWOutput = observer((props: DimmableHSVWOutputProps) => {
               <div className="flex-1 min-h-0">
                 <ColorPicker
                   className="w-full h-full max-w-full max-h-full flex items-center justify-center"
+                  open={isColorWheelOpen}
                   color={color}
                   mode={switchableOutput.type as ColorPickerMode}
                   validModes={switchableOutput.validTypes as ColorPickerValidModes}

--- a/src/app/Marine2/components/views/SwitchingPane.tsx
+++ b/src/app/Marine2/components/views/SwitchingPane.tsx
@@ -10,17 +10,21 @@ import classNames from "classnames"
 import GroupPaginator from "../ui/GroupPaginator/GroupPaginator"
 import Box from "../ui/Box"
 import { translate } from "react-i18nify"
+import { SwitchingPaneContext } from "./SwitchingPaneContext"
+
+let persistedPage = 0
 
 const SwitchingPane = () => {
   const [isModalOpen, setIsModalOpen] = useState(false)
   const switchableOutputs = useSwitchingPane(translate("switches.gxDeviceRelays"))
 
-  const [currentPage, setCurrentPage] = useState(0)
+  const [currentPage, setCurrentPage] = useState(persistedPage)
   const [pageCount, setPageCount] = useState(0)
 
   const currentPageSetter = useCallback((a: number, b: number) => {
     setPageCount(b)
     setCurrentPage(a)
+    persistedPage = a
   }, [])
 
   const { groupNames, groupsOfSwitchableOutputs } = useMemo(() => {
@@ -94,59 +98,63 @@ const SwitchingPane = () => {
             // setIsModalOpen(false)
           }}
           className={classNames("w-5/6 max-w-5/6 h-5/6 max-h-5/6")}
+          preserveLayout
         >
           <Modal.Body variant="popUp" className="h-full bg-surface-primary">
-            <GroupPaginator
-              childrenGroups={groupsOfSwitchableOutputs}
-              orientation="vertical"
-              currentPageSetter={currentPageSetter}
-            >
-              {({
-                columnChildren,
-                groupIndex,
-                groupColumnIndex,
-                groupColumnCount,
-                isFirstColumnOnPage,
-                isFirstColumnOnLastPage,
-              }) => {
-                var displayPageTitle = false
-                // NOTE: display page title for first page in every group
-                if (groupColumnIndex === 0) {
-                  displayPageTitle = true
-                }
-                // NOTE: display page title for first column displayed onscreen
-                if (isFirstColumnOnPage) {
-                  displayPageTitle = true
-                }
-                // NOTE: display page title for first column displayed onscreen
-                // NOTE: when we are on the last page. (which can be non-first column
-                // NOTE: when on the before-last page). Example for three columns:
-                // groups: [a a a] [b b]
-                // page 0: [a _ _]
-                // page 1: [a] [b _]
-                // last column `a` in the first group is also first column on the last page
-                // and should not be displayed unless we are showing the last page
-                if (isFirstColumnOnLastPage && currentPage === pageCount - 1) {
-                  displayPageTitle = true
-                }
-                return (
-                  <div
-                    className={classNames("pt-2 pb-2 h-full", {
-                      "pl-2": groupColumnIndex === 0,
-                      "pr-2": groupColumnIndex === groupColumnCount - 1,
-                    })}
-                  >
-                    <Box
-                      title={displayPageTitle ? groupNames[groupIndex] : "\u00A0"}
-                      roundLeftCorners={groupColumnIndex === 0}
-                      roundRightCorners={groupColumnIndex === groupColumnCount - 1}
+            <SwitchingPaneContext.Provider value={{ isOpen: isModalOpen }}>
+              <GroupPaginator
+                childrenGroups={groupsOfSwitchableOutputs}
+                orientation="vertical"
+                pageNumber={currentPage}
+                currentPageSetter={currentPageSetter}
+              >
+                {({
+                  columnChildren,
+                  groupIndex,
+                  groupColumnIndex,
+                  groupColumnCount,
+                  isFirstColumnOnPage,
+                  isFirstColumnOnLastPage,
+                }) => {
+                  var displayPageTitle = false
+                  // NOTE: display page title for first page in every group
+                  if (groupColumnIndex === 0) {
+                    displayPageTitle = true
+                  }
+                  // NOTE: display page title for first column displayed onscreen
+                  if (isFirstColumnOnPage) {
+                    displayPageTitle = true
+                  }
+                  // NOTE: display page title for first column displayed onscreen
+                  // NOTE: when we are on the last page. (which can be non-first column
+                  // NOTE: when on the before-last page). Example for three columns:
+                  // groups: [a a a] [b b]
+                  // page 0: [a _ _]
+                  // page 1: [a] [b _]
+                  // last column `a` in the first group is also first column on the last page
+                  // and should not be displayed unless we are showing the last page
+                  if (isFirstColumnOnLastPage && currentPage === pageCount - 1) {
+                    displayPageTitle = true
+                  }
+                  return (
+                    <div
+                      className={classNames("pt-2 pb-2 h-full", {
+                        "pl-2": groupColumnIndex === 0,
+                        "pr-2": groupColumnIndex === groupColumnCount - 1,
+                      })}
                     >
-                      {columnChildren}
-                    </Box>
-                  </div>
-                )
-              }}
-            </GroupPaginator>
+                      <Box
+                        title={displayPageTitle ? groupNames[groupIndex] : "\u00A0"}
+                        roundLeftCorners={groupColumnIndex === 0}
+                        roundRightCorners={groupColumnIndex === groupColumnCount - 1}
+                      >
+                        {columnChildren}
+                      </Box>
+                    </div>
+                  )
+                }}
+              </GroupPaginator>
+            </SwitchingPaneContext.Provider>
           </Modal.Body>
         </Modal.Frame>
       </div>

--- a/src/app/Marine2/components/views/SwitchingPaneContext.ts
+++ b/src/app/Marine2/components/views/SwitchingPaneContext.ts
@@ -1,0 +1,3 @@
+import { createContext } from "react"
+
+export const SwitchingPaneContext = createContext({ isOpen: false })


### PR DESCRIPTION
- Add preserveLayout prop to Modal.Frame so only SwitchingPane uses visibility-based hiding (fixes touch event interception on Garmin/Furuno MFDs)
- Persist SwitchingPane page number across component unmount/remount (e.g. opening Diagnostics)
- Fix PageFlipper scroll restoration to use ref + useLayoutEffect, avoiding flash on reopen
- Wire up GroupPaginator pageNumber prop for initial page state
- Fix ColorPicker handleMove using remote color prop instead of localColor during drag
- Suppress remote-to-local color sync while actively dragging to prevent server echo jumps
- Auto-close color wheel when SwitchingPane closes via context
- Reset preset editing state when color picker closes